### PR TITLE
fixing CF_GetSetting for pyrotype, from float to string

### DIFF
--- a/client.qc
+++ b/client.qc
@@ -503,7 +503,7 @@ void () DecodeLevelParms = {
         impulse_queue = CF_GetSetting("impulsequeue", "impulse_queue", "off");
 
         // pyro class type - 0:default; 1:OzTF like; 2:plasmaclass
-        pyro_type = CF_GetSetting("pyrotype", "pyro_type", 1);
+        pyro_type = CF_GetSetting("pyrotype", "pyro_type", "1");
 
         st = infokey(world, "default");
         if (st == "on") {


### PR DESCRIPTION
Error while compiling:
client.qc:506: error: Cannot cast from float to string
changing CF_GetSetting from 1 to "1"