### PR TITLE
Quadmode and ajustments to Clan Mode

### DIFF
--- a/admin.qc
+++ b/admin.qc
@@ -160,7 +160,6 @@ void () Admin_CeaseFire = {
         }
         cease_fire = 0;
         if (cb_prematch) {
-            cb_prematch_time = 0;
             StartTimer();
         }
         bprint(2, "RESUME FIRE\n");
@@ -237,4 +236,5 @@ void () Admin_Aliases =
     TeamFortress_Alias("listips", 198, 0);
     TeamFortress_Alias("clan", 207, 0);
     TeamFortress_Alias("adminmenu", 239, 0);
+    TeamFortress_Alias("startmatch", TF_FORCESTARTMATCH, 0);
 };

--- a/admin.qc
+++ b/admin.qc
@@ -235,6 +235,7 @@ void () Admin_Aliases =
     TeamFortress_Alias("ceasefire", 193, 0);
     TeamFortress_Alias("listips", 198, 0);
     TeamFortress_Alias("clan", 207, 0);
+    TeamFortress_Alias("quadmode", 208, 0);
     TeamFortress_Alias("adminmenu", 239, 0);
     TeamFortress_Alias("startmatch", TF_FORCESTARTMATCH, 0);
     TeamFortress_Alias("readystatus", TF_READYSTATUS, 0);

--- a/admin.qc
+++ b/admin.qc
@@ -237,4 +237,5 @@ void () Admin_Aliases =
     TeamFortress_Alias("clan", 207, 0);
     TeamFortress_Alias("adminmenu", 239, 0);
     TeamFortress_Alias("startmatch", TF_FORCESTARTMATCH, 0);
+    TeamFortress_Alias("readystatus", TF_READYSTATUS, 0);
 };

--- a/clan.qc
+++ b/clan.qc
@@ -17,16 +17,9 @@ void () MatchThink =
         return;
     }
 
-    if ( self.cnt == cvar("timelimit") - 1 && self.cnt2 == 59 ) {
-        localcmd("serverinfo status \"");
-        tmp = ftos(self.cnt + 1);
-        localcmd(tmp);
-        localcmd(" min left\"\n");
-    }
-
     if (self.cnt2 == 1) {
         localcmd("serverinfo status \"");
-        tmp = ftos(self.cnt + 1);
+        tmp = ftos(self.cnt);
         localcmd(tmp);
         localcmd(" min left\"\n");
     }
@@ -764,7 +757,7 @@ void () Broadcast_Players_NotReady = {
         te = find (world, classname, "player");
         while (te != world) {
             if (te.is_ready == 0)
-                sprint(te, 2, "If you are ready, type 'ready' in the console\n");
+                sprint(te, 2, "If you are ready, type \s/ready\s in the console\n");
             te = find(te, classname, "player");
         }
         return;
@@ -841,11 +834,11 @@ void () PreMatch_Message = {
     local entity p = find (world, classname, "player");
     while (p != world) {
         if (p.netname != "") {
-            sprint(p, "Game in \sPREMATCH\s mode.\n");
+            sprint(p, PRINT_HIGH, "Currently in \sprematch\s time\n");
             if (p.is_ready)
-                sprint(p, "You are \sready\s to start the match.\n Type \s/notready\s in the console if you are not ready\n");
+                sprint(p, PRINT_HIGH, "You are \sready\s to start the match.\n Type \s/notready\s in the console if you are not ready\n");
             else
-                sprint(p, "Type \s/ready\s in the console if you are ready to start the match\n");
+                sprint(p, PRINT_HIGH, "Type \s/ready\s in the console if you are ready to start the match\n");
             stuffcmd(p, "play buttons/switch04.wav\n");
         }
         p = find(p, classname, "player");

--- a/clan.qc
+++ b/clan.qc
@@ -106,6 +106,7 @@ void () StartMatch =
     }
     cb_prematch = 0;
     cease_fire = 0;
+
     te = find(world, classname, "prematch");
     te.classname = "match";
     te.cnt = (timelimit / 60);
@@ -275,8 +276,7 @@ void () StartTimer =
 {
     local entity timer;
     local entity p;
-    local float f1;
-    local string tmp;
+    local entity te;
 
     if (clanbattle == 0) {
         if (self != world) {
@@ -305,60 +305,33 @@ void () StartTimer =
         dremove(timer);
         timer = find(timer, classname, "prematch");
     }
-    f1 = stof(infokey (world, "prematch"));
+    te = find(world,classname,"pmmessage");
+    if (te != world) {
+        te.think = SUB_Remove;
+        te.nextthink = 0.01;
+    }
+
+    ResetBreakAndReady(); 
     timer = spawn();
     timer.owner = world;
     timer.classname = "prematch";
     timer.cnt = 0;
-    if (cb_prematch_time) {
-        timer.cnt2 = rint(cb_prematch_time * 60);
-        if (timer.cnt2 < 1) {
-            timer.cnt2 = 1;
-        }
-    }
-    else {
-        ResetBreakAndReady(); 
-        lightstyle (0, "e");
-        if (stof(infokey(world, "demo_auto_left")) > 0) {
-            if (infokey(world, "serverdemo") == "on") {
-                calltimeofday();
-
-                localcmd("record \"");
-                localcmd(ftos (tod_day)); // day
-                localcmd("-");
-                localcmd(ftos (tod_mon)); // month
-                localcmd("-");
-                localcmd(ftos (tod_year)); // year
-                localcmd("_");
-                localcmd(ftos (tod_hour)); // hour
-                localcmd("-");
-                localcmd(ftos (tod_min)); // minute
-                localcmd("-");
-                localcmd(ftos (tod_sec)); // second
-
-                localcmd("_[");
-                localcmd(mapname);
-                localcmd("]");
-                localcmd("\"\n");
-            }
-        }
-        p = find(world, classname, "player");
-        while (p != world) {
-            if (p.netname != "") {
-                stuffcmd(p, "play items/protect2.wav\n");
-            }
-            p = find(timer, classname, "player");
-        }
-        timer.cnt2 = rint(stof(infokey(world, "count")));
-        if (timer.cnt2 < 1) {
-            //By default, 10 seconds of countdown
-            timer.cnt2 = 10;
-        }
+    timer.cnt2 = rint(stof(infokey(world, "count")));
+    if (timer.cnt2 < 1) {
+        //By default, 10 seconds of countdown
+        timer.cnt2 = 10;
     }
     timer.cnt2 = (timer.cnt2 + 1);
     timer.nextthink = (time + 0.1);
-    tmp = ftos(timer.cnt2);
     timer.think = PreMatch_Think;
+
+    p = find(world, classname, "player");
+    while (p != world) {
+        if (p.netname != "") {
+            stuffcmd(p, "play items/protect2.wav\n");
+        }
+        p = find(timer, classname, "player");
+    }
 };
 
 void () StopTimer =
@@ -803,18 +776,17 @@ void () Broadcast_Players_NotReady = {
 }
 
 void () PlayerNotReady = {
-    bprint2 (2, self.netname, " is NOT ready anymore\n ");
-    self.is_ready = 0;
-    v_ready = (v_ready - 1);
-    Broadcast_Players_NotReady();
-    return;
+    if (self.is_ready) {
+        bprint2 (2, self.netname, " is NOT ready anymore\n ");
+        self.is_ready = 0;
+        v_ready = (v_ready - 1);
+        Broadcast_Players_NotReady();
+    }
 }
 
 void () PlayerReady =
 {
     local float f1;
-    local string tmp;
-    local entity te;
 
     if (is_countdown) {
         sprint(self, 2, "You cannot do this after countdown has started.\n");
@@ -846,7 +818,6 @@ void () PlayerReady =
     f1 = TeamFortress_GetNoPlayers ();
     if (v_ready == f1 ) {
         bprint (2, "All players ready, starting match\n");
-        cb_prematch_time = 0;
         StartTimer ();
         return;
     }
@@ -865,3 +836,19 @@ void () RemoveVotes = {
         v_ready = (v_ready - 1);
     }
 };
+
+void () PreMatch_Message = {
+    local entity p = find (world, classname, "player");
+    while (p != world) {
+        if (p.netname != "") {
+            sprint(p, "Game in \sPREMATCH\s mode.\n");
+            if (p.is_ready)
+                sprint(p, "You are \sready\s to start the match.\n Type \s/notready\s in the console if you are not ready\n");
+            else
+                sprint(p, "Type \s/ready\s in the console if you are ready to start the match\n");
+            stuffcmd(p, "play buttons/switch04.wav\n");
+        }
+        p = find(p, classname, "player");
+    }
+    self.nextthink = time + 30;   
+}

--- a/clan.qc
+++ b/clan.qc
@@ -71,7 +71,7 @@ void () StartMatch =
     local entity oldself;
     local entity gren;
 
-    lightstyle(0, "m");    
+    lightstyle(0, "m");
     bprint(2, "MATCH BEGINS NOW\n");
 
     team4score = 0;
@@ -174,6 +174,7 @@ void () PreMatch_Think = {
     }
     else {
         if (!self.cnt2) {
+            is_countdown = 0;
             self.nextthink = (time + 0.1);
             self.think = SUB_Remove;
             p = find(world, classname, "player");
@@ -203,6 +204,7 @@ void () PreMatch_Think = {
     }
     if (self.cnt2 <= 10) {
         if (self.cnt2 == 10) {
+            is_countdown = 1;
             lightstyle(0, "e");
 
             if (stof(infokey(world, "demo_auto_left")) > 0) {
@@ -257,6 +259,18 @@ void () PreMatch_Think = {
     self.nextthink = (time + 1);
 };
 
+void () ResetBreakAndReady = {
+    local entity te;
+    te = find (world, classname, "player");
+    while (te != world) {
+        te.bvote = 0;
+        te.is_ready = 0;
+        v_break = 0;
+        v_ready = 0;
+        te = find (te, classname, "player");
+    }   
+}
+
 void () StartTimer =
 {
     local entity timer;
@@ -303,6 +317,7 @@ void () StartTimer =
         }
     }
     else {
+        ResetBreakAndReady(); 
         lightstyle (0, "e");
         if (stof(infokey(world, "demo_auto_left")) > 0) {
             if (infokey(world, "serverdemo") == "on") {
@@ -755,148 +770,8 @@ void () TeamFortress_ShowIDs = {
         sprint(self, PRINT_HIGH, "None\n");
 };
 
-void () ResetBreakAndReady = {
+void () Broadcast_Players_NotReady = {
     local entity te;
-    te = find (world, classname, "player");
-    while (te != world) {
-        te.bvote = 0;
-        te.is_ready = 0;
-        v_break = 0;
-        v_ready = 0;
-        te = find (te, classname, "player");
-    }   
-}
-
-void () PlayerBreak =
-{
-    local float f1;
-    local float f2;
-    local string tmp;
-
-    if (intermission_running) {
-        return;
-    }
-    if (self.classname != "player") {
-        return;
-    }
-    if (infokey(world, "quadmode") == "on" && (infokey (world, "status") == "Countdown" || infokey(world, "status") == "Standby")) {
-        sprint(self, 2, "You cannot break at this time.\n");
-        return;
-    } 
-    tmp = infokey(world, "votetime");
-    f1 = (stof(tmp) * 60);
-    if (f1 > time) {
-        sprint(self, 2, "You cannot break at this time.\n");
-        return;
-    }
-    if (self.allowvote > time) {
-        return;
-    }
-    self.allowvote = (time + 3);
-    if (self.bvote) {              
-        bprint2(2, self.netname, " \swithdraws\s his/her vote\n");        
-        self.bvote = 0;
-        v_break = (v_break - 1);
-        return;
-    }
-    if (quadmode) {
-        bprint2(3, self.netname, " votes for ending the round\n");
-    }
-    else if (clanbattle) {
-        bprint2(3, self.netname, " votes for stopping the match\n");
-    }
-    else {
-        bprint2(3, self.netname, " votes to end the current map\n");
-    }
-    self.bvote = 1;
-    v_break = (v_break + 1);
-    f1 = TeamFortress_GetNoPlayers();
-    f2 = (floor(f1 / 2) + 1);
-    if (v_break >= f2) {
-        if (quadmode) {
-            bprint(2, "Round ended by majority vote\n");
-            ResetBreakAndReady();
-            EndQuadRound();
-            return;
-        }
-        if (clanbattle) {
-            bprint(2, "Match stopped by majority vote\n");
-        }
-        else {
-            bprint(2, "Map ended by majority vote\n");
-        }
-        StopTimer();
-        NextLevel ();
-        return;
-    }
-    if (v_break != 0) {
-        f1 = (f2 - v_break);
-        tmp = ftos (f1);
-        bprint3(2, "\s", tmp, "\s more vote");
-        if (f1 > 1) {
-            bprint(2, "s");
-        }
-        bprint(2, " needed\n");
-    }
-};
-
-void () PlayerReady =
-{
-    local float f1;
-    local string tmp;
-    local entity te;
-
-    if (quadmode && (infokey (world, "status") == "Countdown")) {
-        sprint (self, 2, "Use 'break' to stop the countdown.\n");
-        return;
-    }
-    if (quadmode && (infokey (world, "status") != "Standby")) {
-        sprint (self, 2, "You cannot do this after the match has started.\n");
-        return;
-    }
-    if (self.team_no == 0) {
-        sprint (self, 2, "You must join a team first.\n");
-        return;
-    }
-    if (self.playerclass == 0) {
-        sprint (self, 2, "You must choose a class first.\n");
-        return;
-    }   
-    if (intermission_running)
-    {
-        return;
-    }
-    if ((self.classname != "player"))
-    {
-        return;
-    }
-    tmp = infokey (world, "votetime");
-    f1 = (stof (tmp) * 60);
-    if (f1 > time) {
-        sprint (self, 2, "You cannot be ready at this time.\n");
-        return;
-    }
-    if (self.allowvote > time) {
-        return;
-    }
-    self.allowvote = (time + 3);
-    if (self.is_ready) {
-        bprint2 (2, self.netname, " is NOT ready anymore\n ");
-        self.is_ready = 0;
-        v_ready = (v_ready - 1);
-        return;
-    }
-    self.is_ready = 1;
-    v_ready = v_ready + 1;
-    bprint2 (3, self.netname, " is ready to start the match\n");
-    f1 = TeamFortress_GetNoPlayers ();
-    if (v_ready == f1 ) {
-        bprint (2, "All players ready, starting match\n");
-        cb_prematch_time = 0;
-        ResetBreakAndReady();
-        StartTimer ();
-        return;
-    }
     if (v_ready != 0) {
         local string players_not_ready = "Not ready: ";
         local float first = 1;
@@ -916,11 +791,66 @@ void () PlayerReady =
         te = find (world, classname, "player");
         while (te != world) {
             if (te.is_ready == 0)
-                sprint (te, 2, "If you are ready, type 'ready' in the console\n");
-            te = find (te, classname, "player");
+                sprint(te, 2, "If you are ready, type 'ready' in the console\n");
+            te = find(te, classname, "player");
         }
         return;
     }
+    else {
+        bprint(1, "No player is ready\n");
+    }
+
+}
+
+void () PlayerNotReady = {
+    bprint2 (2, self.netname, " is NOT ready anymore\n ");
+    self.is_ready = 0;
+    v_ready = (v_ready - 1);
+    Broadcast_Players_NotReady();
+    return;
+}
+
+void () PlayerReady =
+{
+    local float f1;
+    local string tmp;
+    local entity te;
+
+    if (is_countdown) {
+        sprint(self, 2, "You cannot do this after countdown has started.\n");
+        return;
+    }
+    if (infokey (world, "status") != "Standby") {
+        sprint(self, 2, "You cannot do this after the match has started.\n");
+        return;
+    }
+    if (self.team_no == 0) {
+        sprint(self, 2, "You must join a team first.\n");
+        return;
+    }
+    if (self.playerclass == 0) {
+        sprint(self, 2, "You must choose a class first.\n");
+        return;
+    }   
+    if (intermission_running)
+        return;
+    if (self.classname != "player")
+        return;
+    if (self.is_ready) {
+        PlayerNotReady();
+        return;
+    }
+    self.is_ready = 1;
+    v_ready = v_ready + 1;
+    bprint2 (3, self.netname, " is ready to start the match\n");
+    f1 = TeamFortress_GetNoPlayers ();
+    if (v_ready == f1 ) {
+        bprint (2, "All players ready, starting match\n");
+        cb_prematch_time = 0;
+        StartTimer ();
+        return;
+    }
+    Broadcast_Players_NotReady();
 };
 
 void () RemoveVotes = {

--- a/clan.qc
+++ b/clan.qc
@@ -1,3 +1,5 @@
+void () ReturnItem;
+
 void () MatchThink =
 {
     local string tmp;
@@ -90,7 +92,7 @@ void () StartMatch =
         self.frags = 0;
         self.real_frags = 0;        
         setspawnparms(self);
-        if (infokey(world, "quadmode") != "on")
+        if (!quadmode)
             PutClientInServer();
         self = oldself;
         te = find(te, classname, "player");
@@ -122,7 +124,7 @@ void () StartMatch =
         st = ftos(te.cnt);
         localcmd(st);
         localcmd(" min left\"\n");
-        if (infokey(world, "quadmode") != "on") {
+        if (!quadmode) {
             te.think = MatchThink;
             te.nextthink = (time + 1);
         }       
@@ -143,7 +145,11 @@ void () StartMatch =
     localcmd(st);
     localcmd("\n");
 
-    st = infokey(world, "quadmode");
+    if (quadmode) {
+        if (rounds) {
+            StartQuadRound();
+        }
+    }
 };
 
 void () PreMatch_Think = {
@@ -166,8 +172,7 @@ void () PreMatch_Think = {
             p = find(p, classname, "player");
         }
     }
-    else
-    {
+    else {
         if (!self.cnt2) {
             self.nextthink = (time + 0.1);
             self.think = SUB_Remove;
@@ -180,7 +185,10 @@ void () PreMatch_Think = {
                 }
                 p = find(p, classname, "player");
             }
-            StartMatch();
+            if (!quadmode)
+                StartMatch();
+            else 
+                StartQuadRound();
             return;
         }
     }
@@ -196,7 +204,6 @@ void () PreMatch_Think = {
     if (self.cnt2 <= 10) {
         if (self.cnt2 == 10) {
             lightstyle(0, "e");
-            localcmd("serverinfo status Countdown\n");
 
             if (stof(infokey(world, "demo_auto_left")) > 0) {
                 if (infokey(world, "serverdemo") == "on") {
@@ -279,15 +286,6 @@ void () StartTimer =
         }
         return;
     }
-    if (infokey(world, "status") == "Countdown") {
-        if (self != world) {
-            sprint(self, 2, "Countdown in progress....\n");
-        }
-        else {
-            dprint("Countdown in progress....\n");
-        }
-        return;
-    }
     timer = find(world, classname, "prematch");
     while (timer != world) {
         dremove(timer);
@@ -329,7 +327,6 @@ void () StartTimer =
                 localcmd("\"\n");
             }
         }
-        localcmd("serverinfo status Countdown\n");
         p = find(world, classname, "player");
         while (p != world) {
             if (p.netname != "") {
@@ -756,4 +753,185 @@ void () TeamFortress_ShowIDs = {
 
     if (!got_one)
         sprint(self, PRINT_HIGH, "None\n");
+};
+
+void () ResetBreakAndReady = {
+    local entity te;
+    te = find (world, classname, "player");
+    while (te != world) {
+        te.bvote = 0;
+        te.is_ready = 0;
+        v_break = 0;
+        v_ready = 0;
+        te = find (te, classname, "player");
+    }   
+}
+
+void () PlayerBreak =
+{
+    local float f1;
+    local float f2;
+    local string tmp;
+
+    if (intermission_running) {
+        return;
+    }
+    if (self.classname != "player") {
+        return;
+    }
+    if (infokey(world, "quadmode") == "on" && (infokey (world, "status") == "Countdown" || infokey(world, "status") == "Standby")) {
+        sprint(self, 2, "You cannot break at this time.\n");
+        return;
+    } 
+    tmp = infokey(world, "votetime");
+    f1 = (stof(tmp) * 60);
+    if (f1 > time) {
+        sprint(self, 2, "You cannot break at this time.\n");
+        return;
+    }
+    if (self.allowvote > time) {
+        return;
+    }
+    self.allowvote = (time + 3);
+    if (self.bvote) {              
+        bprint2(2, self.netname, " \swithdraws\s his/her vote\n");        
+        self.bvote = 0;
+        v_break = (v_break - 1);
+        return;
+    }
+    if (quadmode) {
+        bprint2(3, self.netname, " votes for ending the round\n");
+    }
+    else if (clanbattle) {
+        bprint2(3, self.netname, " votes for stopping the match\n");
+    }
+    else {
+        bprint2(3, self.netname, " votes to end the current map\n");
+    }
+    self.bvote = 1;
+    v_break = (v_break + 1);
+    f1 = TeamFortress_GetNoPlayers();
+    f2 = (floor(f1 / 2) + 1);
+    if (v_break >= f2) {
+        if (quadmode) {
+            bprint(2, "Round ended by majority vote\n");
+            ResetBreakAndReady();
+            EndQuadRound();
+            return;
+        }
+        if (clanbattle) {
+            bprint(2, "Match stopped by majority vote\n");
+        }
+        else {
+            bprint(2, "Map ended by majority vote\n");
+        }
+        StopTimer();
+        NextLevel ();
+        return;
+    }
+    if (v_break != 0) {
+        f1 = (f2 - v_break);
+        tmp = ftos (f1);
+        bprint3(2, "\s", tmp, "\s more vote");
+        if (f1 > 1) {
+            bprint(2, "s");
+        }
+        bprint(2, " needed\n");
+    }
+};
+
+void () PlayerReady =
+{
+    local float f1;
+    local string tmp;
+    local entity te;
+
+    if (quadmode && (infokey (world, "status") == "Countdown")) {
+        sprint (self, 2, "Use 'break' to stop the countdown.\n");
+        return;
+    }
+    if (quadmode && (infokey (world, "status") != "Standby")) {
+        sprint (self, 2, "You cannot do this after the match has started.\n");
+        return;
+    }
+    if (self.team_no == 0) {
+        sprint (self, 2, "You must join a team first.\n");
+        return;
+    }
+    if (self.playerclass == 0) {
+        sprint (self, 2, "You must choose a class first.\n");
+        return;
+    }   
+    if (intermission_running)
+    {
+        return;
+    }
+    if ((self.classname != "player"))
+    {
+        return;
+    }
+    tmp = infokey (world, "votetime");
+    f1 = (stof (tmp) * 60);
+    if (f1 > time) {
+        sprint (self, 2, "You cannot be ready at this time.\n");
+        return;
+    }
+    if (self.allowvote > time) {
+        return;
+    }
+    self.allowvote = (time + 3);
+    if (self.is_ready) {
+        bprint2 (2, self.netname, " is NOT ready anymore\n ");
+        self.is_ready = 0;
+        v_ready = (v_ready - 1);
+        return;
+    }
+    self.is_ready = 1;
+    v_ready = v_ready + 1;
+    bprint2 (3, self.netname, " is ready to start the match\n");
+    f1 = TeamFortress_GetNoPlayers ();
+    if (v_ready == f1 ) {
+        bprint (2, "All players ready, starting match\n");
+        cb_prematch_time = 0;
+        ResetBreakAndReady();
+        StartTimer ();
+        return;
+    }
+    if (v_ready != 0) {
+        local string players_not_ready = "Not ready: ";
+        local float first = 1;
+        te = find (world, classname, "player");
+        while (te != world) {
+            if (te.is_ready == 0) {
+                if (!first)
+                    players_not_ready = strcat(players_not_ready, ", ");
+                else
+                    first = 0;                      
+                players_not_ready = strcat(players_not_ready, te.netname);
+            }
+            te = find (te, classname, "player");
+        }   
+        players_not_ready = strcat(players_not_ready, "\n");
+        bprint(1, players_not_ready);
+        te = find (world, classname, "player");
+        while (te != world) {
+            if (te.is_ready == 0)
+                sprint (te, 2, "If you are ready, type 'ready' in the console\n");
+            te = find (te, classname, "player");
+        }
+        return;
+    }
+};
+
+void () RemoveVotes = {
+    if (self.bvote) {
+        bprint2(2, self.netname, " \swithdraws\s his/her vote\n");
+        self.bvote = 0;
+        v_break = (v_break - 1);
+    }
+    if (self.is_ready) {
+        bprint2(2, self.netname, " is NOT ready anymore\n ");
+        self.is_ready = 0;
+        v_ready = (v_ready - 1);
+    }
 };

--- a/client.qc
+++ b/client.qc
@@ -2055,7 +2055,7 @@ void () ClientConnect = {
         }
     }
     if (cb_prematch)
-        sprint(self, PRINT_HIGH, "Currently in prematch time\n");
+        sprint(self, PRINT_HIGH, "Currently in \sprematch\s time\n");
 };
 
 void () ClientDisconnect = {

--- a/client.qc
+++ b/client.qc
@@ -256,6 +256,8 @@ void () DecodeLevelParms = {
         autoteam_time = 30;
 
         clanbattle = CF_GetSetting("c", "clan", "off");
+        quadmode = CF_GetSetting("quadmode", "quadmode", "off");
+        
         if (clanbattle) {
             localcmd ("serverinfo status Standby\n");
             

--- a/client.qc
+++ b/client.qc
@@ -55,6 +55,7 @@ void () StopTimer;
 void () StartQuadRound;
 void (string cl_pwd) Admin_Check;
 void () Admin_Aliases;
+void () PreMatch_Message;
 
 
 string nextmap;
@@ -270,37 +271,12 @@ void () DecodeLevelParms = {
             
             clan_scores_dumped = 0;
             game_locked = 0;
-
             cb_prematch = 1;
-            cb_prematch_time = CF_GetSetting("pm", "prematch", "0");
-            if (cb_prematch_time)
-            {
-                StartTimer();
-            }
-            if (!cb_prematch_time) {
-              cb_ceasefire_time = CF_GetSetting("cft", "ceasefire_time", "0");
-                if (cb_ceasefire_time) {
-
-                    cease_fire = 1;
-                    bprint (2, "CEASE FIRE\n");
-                    te = find (world, classname, "player");
-                    while (te)
-                    {
-                        centerprint (te, "CEASE FIRE\n");
-                        te.immune_to_check = (time + 5);
-                        te.tfstate = (te.tfstate | TFSTATE_CANT_MOVE);
-                        TeamFortress_SetSpeed (te);
-                        te = find (te, classname, "player");
-                    }
-                    te = spawn ();
-                    te.classname = "ceasefire";
-                    te.think = CeaseFire_think;
-                    te.nextthink = (time + 5);
-                    te.weapon = 1;
-                    StartTimer();
-
-                }  
-            }
+            local entity pm_message = spawn();
+            pm_message.owner = world;
+            pm_message.classname = "pmmessage";
+            pm_message.think = PreMatch_Message;
+            pm_message.nextthink = 1;
             
             game_locked = CF_GetSetting("lg", "locked_game", "off");
 
@@ -1292,11 +1268,6 @@ void () PutClientInServer = {
     if (self.playerclass != 0)
         spawn_tdeath(self.origin, self);
 
-    if (cb_prematch_time < time) {
-       bprint(2,"TEST PREMATCH\n");
-    bprint(2,"TEST PREMATCH\n");
-    bprint(2,"TEST PREMATCH\n"); 
-    }
     if ((spot.classname == "info_player_teamspawn") &&
         (!cb_prematch)) {
         
@@ -2068,7 +2039,7 @@ void () ClientConnect = {
             }
         }
         if (!got_one) {
-            if (game_locked && (cb_prematch_time < time)) {
+            if (game_locked && (!cb_prematch)) {
                 sprint(self, PRINT_HIGH,
                        "Closed server. Clan battle in progress.\n");
                 KickCheater(self);
@@ -2630,7 +2601,7 @@ void (entity targ, entity attacker) ClientObituary = {
 
     Sniper_ZoomReset(targ);
 
-    if ((cb_prematch_time + 3) > time)
+    if (cb_prematch)
         return;
 
     deathstring = GetDeathMessage(targ, attacker, deathmsg);

--- a/client.qc
+++ b/client.qc
@@ -1292,8 +1292,14 @@ void () PutClientInServer = {
     if (self.playerclass != 0)
         spawn_tdeath(self.origin, self);
 
+    if (cb_prematch_time < time) {
+       bprint(2,"TEST PREMATCH\n");
+    bprint(2,"TEST PREMATCH\n");
+    bprint(2,"TEST PREMATCH\n"); 
+    }
     if ((spot.classname == "info_player_teamspawn") &&
-        (cb_prematch_time < time)) {
+        (!cb_prematch)) {
+        
         if (spot.items != 0) {
             te = Finditem(spot.items);
             if (te)

--- a/client.qc
+++ b/client.qc
@@ -52,6 +52,7 @@ void () CTF_FlagCheck;
 void (entity pl) Sniper_ZoomReset;
 void () StartTimer;
 void () StopTimer;
+void () StartQuadRound;
 void (string cl_pwd) Admin_Check;
 void () Admin_Aliases;
 
@@ -257,7 +258,13 @@ void () DecodeLevelParms = {
 
         clanbattle = CF_GetSetting("c", "clan", "off");
         quadmode = CF_GetSetting("quadmode", "quadmode", "off");
-        
+
+        rounds = CF_GetSetting("rounds","rounds","on");
+        if (!rounds)
+            rounds = -1;
+        else if (rounds > 0)
+            rounds = rounds + 1;
+
         if (clanbattle) {
             localcmd ("serverinfo status Standby\n");
             
@@ -300,6 +307,13 @@ void () DecodeLevelParms = {
         } else {
             clanbattle = FALSE;
             localcmd ("serverinfo status Normal\n");
+        }
+        if (rounds) {
+            st = infokey (world, "round_time");
+            te = spawn ();
+            te.owner = world;
+            te.classname = "round";
+            te.cnt = stof(st);
         }
 
         // automatically assign team [off]

--- a/client.qc
+++ b/client.qc
@@ -503,7 +503,7 @@ void () DecodeLevelParms = {
         impulse_queue = CF_GetSetting("impulsequeue", "impulse_queue", "off");
 
         // pyro class type - 0:default; 1:OzTF like; 2:plasmaclass
-        pyro_type = CF_GetSetting("pyrotype", "pyro_type", 0);
+        pyro_type = CF_GetSetting("pyrotype", "pyro_type", 1);
 
         st = infokey(world, "default");
         if (st == "on") {
@@ -554,7 +554,7 @@ void () DecodeLevelParms = {
             old_hp_armor = FALSE;
             ng_velocity = 1500;
             old_ng_rof = FALSE;
-            pyro_type = 0;
+            pyro_type = 1;
         }
 
         st = infokey(world, "faithful");

--- a/commands.qc
+++ b/commands.qc
@@ -8,7 +8,7 @@ void () QuadMode =
 		st = "off";
 		localcmd ("localinfo clan off\n");
 		localcmd ("localinfo quadmode off\n");
-		localcmd ("rounds off");
+		localcmd ("localinfo rounds 0");
 	}
 	else
 	{

--- a/commands.qc
+++ b/commands.qc
@@ -1,3 +1,28 @@
+void () QuadMode =
+{
+	local string st;
+
+	st = infokey (world, "quadmode");
+	if ((st == "on"))
+	{
+		st = "off";
+		localcmd ("localinfo clan off\n");
+		localcmd ("localinfo quadmode off\n");
+		localcmd ("rounds off");
+	}
+	else
+	{
+		st = "on";
+		localcmd ("localinfo clan on\n");
+		localcmd ("localinfo quadmode on\n");
+		localcmd ("localinfo rounds 2\n");
+		localcmd ("timelimit 0\n");
+		localcmd ("localinfo round_time 10\n");
+		bprint (2, "Map Restart needed to take affect!\n");
+	}
+	bprint3 (2, "Quad Mode set to ", st, "\n");
+};
+
 void () ClanMode =
 {
 	local string st;

--- a/defs.h
+++ b/defs.h
@@ -460,7 +460,7 @@
 #define TF_PLAYER_READY         135
 #define TF_PLAYER_NOT_READY     136
 #define TF_FORCESTARTMATCH      137
-// unused                       138
+#define TF_READYSTATUS          138
 // unused                       139
 // unused                       140
 // unused                       141

--- a/defs.h
+++ b/defs.h
@@ -457,9 +457,9 @@
 #define TF_VOTETRICK            132 // Vote to start voting for a trick map
 #define TF_VOTERACE             133 // Vote to start voting for a race map
 #define TF_FORCENEXT            134 // Vote to force a change to voted map
-// unused                       135
-// unused                       136
-// unused                       137
+#define TF_PLAYERREADY          135
+#define TF_PLAYERBREAK          136
+#define TF_FORCESTARTMATCH       137
 // unused                       138
 // unused                       139
 // unused                       140

--- a/defs.h
+++ b/defs.h
@@ -457,9 +457,9 @@
 #define TF_VOTETRICK            132 // Vote to start voting for a trick map
 #define TF_VOTERACE             133 // Vote to start voting for a race map
 #define TF_FORCENEXT            134 // Vote to force a change to voted map
-#define TF_PLAYERREADY          135
-#define TF_PLAYERBREAK          136
-#define TF_FORCESTARTMATCH       137
+#define TF_PLAYER_READY         135
+#define TF_PLAYER_NOT_READY     136
+#define TF_FORCESTARTMATCH      137
 // unused                       138
 // unused                       139
 // unused                       140

--- a/mvdsv.qc
+++ b/mvdsv.qc
@@ -274,5 +274,10 @@ float () ConsoleCmd {
         ClanMode();
         return (1);
     }
+    else if (argv_mvdsv (0) == "quadmode")
+    {
+        QuadMode ();
+        return (1);
+    }
     return 0;
 }

--- a/mvdsv.qc
+++ b/mvdsv.qc
@@ -276,7 +276,7 @@ float () ConsoleCmd {
     }
     else if (argv_mvdsv (0) == "quadmode")
     {
-        QuadMode ();
+        QuadMode();
         return (1);
     }
     return 0;

--- a/player.qc
+++ b/player.qc
@@ -44,7 +44,7 @@ void () player_touch = {
             }
         }
     }
-    if ((self.tfstate & 16) && (cb_prematch_time < time)) {
+    if ((self.tfstate & 16) && (!cb_prematch)) {
         if ((other.classname == "player") && (te.playerclass != 0)) {
             if (!(other.tfstate & 16)) {
                 if (other.playerclass != 5) {

--- a/progs.src
+++ b/progs.src
@@ -37,6 +37,7 @@ spy.qc
 engineer.qc
 camera.qc
 clan.qc
+quadmode.qc
 tfort.qc
 tforthlp.qc
 tfortmap.qc

--- a/quadmode.qc
+++ b/quadmode.qc
@@ -36,10 +36,7 @@ float () CheckWinningTeam = {
 };
 
 void () QuadRoundOver = {
-	local string st;
-
 	round_over = 2;
-
 	self.think = StartQuadRound;
 	self.nextthink = (time + 0.5);
 };
@@ -60,8 +57,7 @@ void () QuadRoundThink = {
 	}
 
 	if (self.cnt == -1)
-		return;
-	
+		return;	
 
 	if ( self.cnt == stof(infokey(world, "round_time")) - 1 && self.cnt2 == 59 ) {
 		localcmd("serverinfo status \"");
@@ -84,12 +80,11 @@ void () QuadRoundThink = {
 
 	if (!cease_fire)
 		self.cnt2 = (self.cnt2 - 1);
-
-	localcmd(sprintf("timelimit %s\n", ftos(stof(infokey(world, "round_time")))));
+	
 	if (!self.cnt2)	{
 		if ((self.cnt == 1) || (self.cnt == 5)) {
 			tmp = ftos (self.cnt);
-			bprint3(2, "", tmp, "‘ minute");
+			bprint3(2, "\s[\s", tmp, "\s]\s minute");
 			if (self.cnt != 1) 
 				bprint(2, "s");
 			bprint(2, " remaining\n");
@@ -99,18 +94,17 @@ void () QuadRoundThink = {
 				bprint(2, "ROUND TIME OVER\nNext round begins in 10 seconds\n");
 
 //			lightstyle (0, "e");
-			localcmd("serverinfo status Countdown\n");
 
 			self.think = QuadRoundOver;
 			self.nextthink = (time + 0.1);
 			return;
 		}
 	}
-	if (!self.cnt && (((self.cnt2 == 30) || (self.cnt2 == 15)) || (self.cnt2 <= enter))) {
+	if (!self.cnt && (((self.cnt2 == 30) || (self.cnt2 == 15)) || (self.cnt2 <= 10))) {
 		fl = ceil (self.cnt2);
 		if (!(fl - self.cnt2)) {
 			tmp = ftos(self.cnt2);
-			bprint3(2, "", tmp, "‘ second");
+			bprint3(2, "\s[\s", tmp, "\s]\s second");
 			if ((self.cnt2 != 1))
 				bprint(2, "s");			
 			bprint(2, " remaining\n");
@@ -121,13 +115,11 @@ void () QuadRoundThink = {
 };
 
 void () QuadRoundBegin = {
+
 	local entity te;
 	local entity oldself;
-	local string st;
-	local string tmp;
-	local float bomber;
 	local float counter;
-
+	localcmd(strcat(strcat("timelimit ", ftos(stof(infokey(world, "round_time")))), "\n"));
 	te = find(world, classname, "func_breakable");
 	while (te) {
 		setmodel(te, te.mdl);
@@ -138,11 +130,6 @@ void () QuadRoundBegin = {
 	while (te != world) {
 		oldself = self;
 		self = te;
-		if (self.hook_out) {
-			Reset_Grapple(self.hook);
-			Attack_Finished(0.75);
-			self.hook_out = 1;
-		}
 		TeamFortress_RemoveTimers();
 		setspawnparms(self);
 		PutClientInServer();
@@ -151,14 +138,9 @@ void () QuadRoundBegin = {
 	}
 //	lightstyle (0, "m");
 
-	localcmd("serverinfo status \"");
-
 	bprint(2, "QUAD ROUND BEGINS NOW\n");
-	round_active = 1;
+ 	round_active = 1;
 	round_over = 0;
-	if (speedcap) {
-		self.invisible_time = time;
-	}
 	if (!self.cnt) {
 		self.cnt = stof(infokey (world, "round_time")) - 1;		
 		self.cnt2 = 60;
@@ -174,17 +156,20 @@ void () QuadRoundBegin = {
 		else
 			self.cnt = counter;
 	}
+	self.cnt2 = self.cnt2 + 1;
+	localcmd("serverinfo status \"");
+	local string tmp = ftos (self.cnt + 1);
+	localcmd(tmp);
+	localcmd(" min left\"\n");
 	self.think = QuadRoundThink;
-	self.nextthink = (time + 0.1);
+	self.nextthink = (time + 0.001);
 };
 
 void () QuadRoundInit = {
 	local string num;
-	local float fl;
 	local entity p;
 
-	fl = TeamFortress_NoTeams();
-	if ((fl < 1) || cease_fire)	{
+	if ((number_of_teams < 1) || cease_fire)	{
 		self.nextthink = (time + 2);
 		if (self.cnt2 <= 5)
 			self.cnt2 = 10;
@@ -195,10 +180,8 @@ void () QuadRoundInit = {
 		round_over = 2;
 	if (self.cnt2 == 1)	{
 		p = find(world, classname, "player");
-		while (p != world)
-		{
-			if (p.netname != "")
-			{
+		while (p != world) {
+			if (p.netname != "") {
 				p.takedamage = 0;
 				p.solid = 0;
 				p.movetype = 0;
@@ -225,7 +208,7 @@ void () QuadRoundInit = {
 		}
 	}
 	if (self.cnt2 <= 5)	{
-		num = ftos (self.cnt2);
+		num = ftos(self.cnt2);
 		p = find (world, classname, "player");
 		while (p != world) {
 			if (p.netname != "") {
@@ -233,7 +216,7 @@ void () QuadRoundInit = {
 				cease_fire = 0;
 				stuffcmd(p, "play buttons/switch04.wav\n");
 			}
-			p = find (p, classname, "player");
+			p = find(p, classname, "player");
 		}
 	}
 	self.nextthink = (time + 1);
@@ -249,6 +232,9 @@ void () StartQuadRound =
 	local entity gren;
 	local entity p;
 
+	lightstyle(0, "m");
+	cb_prematch = 0;
+    cease_fire = 0;
 
 	if (rounds == 1) {
 		quad_winner = CheckWinningTeam();
@@ -282,7 +268,6 @@ void () StartQuadRound =
 	if (intermission_running)
 		return;
 
-	tfs_winner = 0;
 	round_over = 1;
 
 	te = find(world, classname, "info_tfgoal");
@@ -304,124 +289,95 @@ void () StartQuadRound =
 		door_go_down();
 		self.think = LinkDoors;
 		self = te2;
-		te = find (te, classname, "door");
+		te = find(te, classname, "door");
 	}
 
 
-	if (round_active)
-	{
-		te = find (world, classname, "player");
+	if (round_active) {
+		te = find(world, classname, "player");
 		while (te != world)	{
 			oldself = self;
 			self = te;
-			if (self.hook_out) {
-				Reset_Grapple (self.hook);
-				Attack_Finished (0.75);
-				self.hook_out = 1;
-			}
 			self.menu_count = 30;
 			self.current_menu = 1;
-			TeamFortress_ThrowGrenade ();
-			TeamFortress_RemoveTimers ();
+			TeamFortress_ThrowGrenade();
+			TeamFortress_RemoveTimers();
 			if (self.playerclass == 9) {
-				Engineer_RemoveBuildings (self);
+				Engineer_RemoveBuildings(self);
 			}
 			self = oldself;
 			te = find (te, classname, "player");
 		}
 		round_active = 0;
 	}
-	gren = find (world, classname, "grenade");
-	while (gren)
-	{
+	gren = find(world, classname, "grenade");
+	while (gren) {
 		gren.think = SUB_Remove;
 		gren.nextthink = (time + 0.1);
-		gren = find (gren, classname, "grenade");
+		gren = find(gren, classname, "grenade");
 	}
-	gren = find (world, classname, "grentimer");
-	while (gren)
-	{
+	gren = find(world, classname, "grentimer");
+	while (gren) {
 		gren.think = SUB_Remove;
 		gren.nextthink = (time + 0.1);
-		gren = find (gren, classname, "grentimer");
+		gren = find(gren, classname, "grentimer");
 	}
-	te = find (world, classname, "detpack");
-	while (te)
-	{
-		if ((te.weaponmode == 1))
-		{
+	te = find(world, classname, "detpack");
+	while (te){
+		if (te.weaponmode == 1) {
 			TeamFortress_SetSpeed (te.enemy);
-			dremove (te.oldenemy);
-			dremove (te.observer_list);
+			dremove(te.oldenemy);
+			dremove(te.observer_list);
 		}
-		dremove (te.linked_list);
-		dremove (te);
+		dremove(te.linked_list);
+		dremove(te);
 		te = find (te, classname, "detpack");
 	}
-	te = find (world, classname, "item_tfgoal");
-	while (te)
-	{
-		if ((te.origin != te.oldorigin))
-		{
-			oldself = spawn ();
+	te = find(world, classname, "item_tfgoal");
+	while (te) {
+		bprint(2,"Goal Name: ");
+		bprint(2,te.netname);
+		bprint(2, "\n");
+		if (te.origin != te.oldorigin) {
+			oldself = spawn();
 			oldself.enemy = te;
 			oldself.weapon = 3;
 			oldself.nextthink = (time + 0.2);
 			oldself.think = ReturnItem;
 		}
-		te = find (te, classname, "item_tfgoal");
+		te = find(te, classname, "item_tfgoal");
 	}
-	te = find (world, classname, "item_ball");
-	while (te)
-	{
-		if ((te.origin != te.oldorigin))
-		{
-			te.nextthink = (time + 0.3);
-			te.think = ball_reset;
-		}
-		te = find (te, classname, "item_ball");
-	}
-	te = find (world, classname, "ammobox");
-	while (te)
-	{
-		te.nextthink = (time + 0.3);
-		te.think = TeamFortress_AmmoboxThink;
-		te = find (te, classname, "ammobox");
-	}
-	te = find (world, classname, "round");
-	st = infokey (world, "count");
-	fl = stof (st);
-	if ((fl < 3) || (fl > 20))
-	{
-		fl = enter;
+	te = find(world, classname, "round");
+	st = infokey(world, "count");
+	fl = stof(st);
+	if ((fl < 3) || (fl > 20)) {
+		fl = 10;
 	}
 	te.cnt2 = 10;
 	st = infokey (world, "round_time");
 	te.cnt = stof (st);
-	quad_winner = CheckWinningTeam();	
+	quad_winner = CheckWinningTeam();
+	bprint(2, ftos(rounds));
+	bprint(2, "\n");
+	localcmd("serverinfo status Standby\n");
 	if (rounds > 1) {
-//		lightstyle (0, "e");
-		localcmd("serverinfo status Countdown\n");
 		te.think = QuadRoundBegin;
 		te.nextthink = (time + 0.01);
 	}
 	else {
-//		lightstyle (0, "e");
-		localcmd("serverinfo status Countdown\n");
 		te.think = QuadRoundInit;
 		te.nextthink = (time + 1); 
 	}
 };
 
-void () EndRound = {
+void () EndQuadRound = {
 	if (infokey(world, "quadmode") == "on") {
 		if (infokey(world,"status") != "Countdown" && infokey(world,"status") != "Standby") {
 			if (rounds > 1) {
 				bprint (2, "ROUND TIME OVER\nNext round begins in 10 seconds\n");
-//					lightstyle (0, "e");
-					localcmd("serverinfo status Countdown\n");
-					self.think = QuadRoundOver;
-					self.nextthink = (time + 0.1);
+				lightstyle (0, "e");
+				self.think = QuadRoundOver;
+				self.nextthink = (time + 0.1);
 			}
 			else if (rounds == 1) {
 				StartQuadRound();

--- a/quadmode.qc
+++ b/quadmode.qc
@@ -1,0 +1,431 @@
+//=-=-=-=-=
+
+float () CheckWinningTeam = {
+	local float win_score = 0;
+	local float winning_team = 0;
+
+	if (team1score > win_score) {
+		win_score = team1score;
+		winning_team = 1;
+	}
+	
+	if (team2score > win_score) {
+		win_score = team2score;
+		winning_team = 2;
+	}
+	else if (team2score == win_score) {
+		winning_team = 0;
+	}
+
+	if (team3score > win_score) {
+		win_score = team3score;
+		winning_team = 3;
+	}
+	else if (team3score == win_score) {
+		winning_team = 0;
+	}
+
+	if (team4score > win_score) {
+		win_score = team4score;
+		winning_team = 4;
+	}
+	else if (team4score == win_score) {
+		winning_team = 0;
+	}
+	return winning_team;
+};
+
+void () QuadRoundOver = {
+	local string st;
+
+	round_over = 2;
+
+	self.think = StartQuadRound;
+	self.nextthink = (time + 0.5);
+};
+
+void () QuadRoundThink = {
+	local string tmp;
+	local float fl;
+
+	if (rounds < 2) {
+		if (CheckWinningTeam() != 0) {
+			if (quad_winner != CheckWinningTeam()) {
+				quad_winner = CheckWinningTeam();
+				self.think = QuadRoundOver;
+				self.nextthink = (time + 0.1);
+				return;
+			}
+		}
+	}
+
+	if (self.cnt == -1)
+		return;
+	
+
+	if ( self.cnt == stof(infokey(world, "round_time")) - 1 && self.cnt2 == 59 ) {
+		localcmd("serverinfo status \"");
+		tmp = ftos (self.cnt + 1);
+		localcmd(tmp);
+		localcmd(" min left\"\n");
+	}
+
+	if (self.cnt2 == 1) {
+		localcmd("serverinfo status \"");
+		tmp = ftos (self.cnt);
+		localcmd(tmp);
+		localcmd(" min left\"\n");
+	}
+
+	if (self.cnt2 == -1) {
+		self.cnt2 = 59;
+		self.cnt = (self.cnt - 1);		
+	}
+
+	if (!cease_fire)
+		self.cnt2 = (self.cnt2 - 1);
+
+	localcmd(sprintf("timelimit %s\n", ftos(stof(infokey(world, "round_time")))));
+	if (!self.cnt2)	{
+		if ((self.cnt == 1) || (self.cnt == 5)) {
+			tmp = ftos (self.cnt);
+			bprint3(2, "", tmp, "‘ minute");
+			if (self.cnt != 1) 
+				bprint(2, "s");
+			bprint(2, " remaining\n");
+		}
+		if (!self.cnt) {
+			if (rounds > 1)
+				bprint(2, "ROUND TIME OVER\nNext round begins in 10 seconds\n");
+
+//			lightstyle (0, "e");
+			localcmd("serverinfo status Countdown\n");
+
+			self.think = QuadRoundOver;
+			self.nextthink = (time + 0.1);
+			return;
+		}
+	}
+	if (!self.cnt && (((self.cnt2 == 30) || (self.cnt2 == 15)) || (self.cnt2 <= enter))) {
+		fl = ceil (self.cnt2);
+		if (!(fl - self.cnt2)) {
+			tmp = ftos(self.cnt2);
+			bprint3(2, "", tmp, "‘ second");
+			if ((self.cnt2 != 1))
+				bprint(2, "s");			
+			bprint(2, " remaining\n");
+		}
+	}
+	gametime++;
+	self.nextthink = (time + 1);
+};
+
+void () QuadRoundBegin = {
+	local entity te;
+	local entity oldself;
+	local string st;
+	local string tmp;
+	local float bomber;
+	local float counter;
+
+	te = find(world, classname, "func_breakable");
+	while (te) {
+		setmodel(te, te.mdl);
+		te.solid = 4;
+		te = find(te, classname, "func_breakable");
+	}
+	te = find(world, classname, "player");
+	while (te != world) {
+		oldself = self;
+		self = te;
+		if (self.hook_out) {
+			Reset_Grapple(self.hook);
+			Attack_Finished(0.75);
+			self.hook_out = 1;
+		}
+		TeamFortress_RemoveTimers();
+		setspawnparms(self);
+		PutClientInServer();
+		self = oldself;
+		te = find (te, classname, "player");
+	}
+//	lightstyle (0, "m");
+
+	localcmd("serverinfo status \"");
+
+	bprint(2, "QUAD ROUND BEGINS NOW\n");
+	round_active = 1;
+	round_over = 0;
+	if (speedcap) {
+		self.invisible_time = time;
+	}
+	if (!self.cnt) {
+		self.cnt = stof(infokey (world, "round_time")) - 1;		
+		self.cnt2 = 60;
+	}
+	else {
+		counter = floor(self.cnt);
+		if (counter < self.cnt) 
+			self.cnt2 = ((self.cnt - counter) * 60);
+		else
+			self.cnt2 = 60;
+		if (self.cnt2 == 60)
+			self.cnt = (self.cnt - 1);
+		else
+			self.cnt = counter;
+	}
+	self.think = QuadRoundThink;
+	self.nextthink = (time + 0.1);
+};
+
+void () QuadRoundInit = {
+	local string num;
+	local float fl;
+	local entity p;
+
+	fl = TeamFortress_NoTeams();
+	if ((fl < 1) || cease_fire)	{
+		self.nextthink = (time + 2);
+		if (self.cnt2 <= 5)
+			self.cnt2 = 10;
+		return;
+	}
+	self.cnt2 = (self.cnt2 - 1);
+	if (self.cnt2 == 2)
+		round_over = 2;
+	if (self.cnt2 == 1)	{
+		p = find(world, classname, "player");
+		while (p != world)
+		{
+			if (p.netname != "")
+			{
+				p.takedamage = 0;
+				p.solid = 0;
+				p.movetype = 0;
+				p.modelindex = 0;
+				p.model = string_null;
+			}
+			p = find(p, classname, "player");
+		}
+	}
+	else {
+		if (!self.cnt2)	{
+			self.nextthink = (time + 0.1);
+			self.think = QuadRoundBegin;
+			p = find(world, classname, "player");
+			while (p != world) {
+				if (p.netname != "") {
+					p.takedamage = 2;
+					p.solid = 3;
+					p.movetype = 3;
+				}
+				p = find(p, classname, "player");
+			}
+			return;
+		}
+	}
+	if (self.cnt2 <= 5)	{
+		num = ftos (self.cnt2);
+		p = find (world, classname, "player");
+		while (p != world) {
+			if (p.netname != "") {
+				CenterPrint3(p, "Round begins in: ", num, " second(s).\n");
+				cease_fire = 0;
+				stuffcmd(p, "play buttons/switch04.wav\n");
+			}
+			p = find (p, classname, "player");
+		}
+	}
+	self.nextthink = (time + 1);
+};
+
+void () StartQuadRound =
+{
+	local string st;
+	local float fl;
+	local entity te;
+	local entity te2;
+	local entity oldself;
+	local entity gren;
+	local entity p;
+
+
+	if (rounds == 1) {
+		quad_winner = CheckWinningTeam();
+		if (quad_winner == 0)
+			bprint (2, "Round Drawn!\n");
+		else if (quad_winner == 1)
+			bprint(2, "Blue Team Wins!\n");
+		else if (quad_winner == 2)
+			bprint(2, "Red Team Wins!\n");
+		else if (quad_winner == 3)
+			bprint(2, "Yellow Team Wins!\n");
+		else if (quad_winner == 4)
+			bprint(2, "Green Team Wins!\n");
+		p = find (world, classname, "player");
+		while (p != world) {
+			if (p.netname != "") {
+				p.takedamage = 0;
+				p.solid = 0;
+				p.movetype = 0;
+				p.modelindex = 0;
+				p.model = string_null;
+			}
+			p = find(p, classname, "player");
+		}
+		bprint(2, "Rounds Over! Use \"cmd map <mapname>\" to go to the nextmap\n");
+		localcmd("stop\n");
+		return;
+	}
+	if (rounds > 1)
+		rounds = (rounds - 1);
+	if (intermission_running)
+		return;
+
+	tfs_winner = 0;
+	round_over = 1;
+
+	te = find(world, classname, "info_tfgoal");
+	while (te != world) {
+		if (te.netname == "blue_det" || te.netname == "red_det") {
+			te2 = self;
+			self = te;
+			self.goal_activation = 2;
+			self.solid = 1;
+			self.goal_state = 2;
+			self = te2;
+		}
+		te = find(te, classname, "info_tfgoal");
+	}
+	te = find(world, classname, "door");
+	while (te != world) {
+		te2 = self;
+		self = te;
+		door_go_down();
+		self.think = LinkDoors;
+		self = te2;
+		te = find (te, classname, "door");
+	}
+
+
+	if (round_active)
+	{
+		te = find (world, classname, "player");
+		while (te != world)	{
+			oldself = self;
+			self = te;
+			if (self.hook_out) {
+				Reset_Grapple (self.hook);
+				Attack_Finished (0.75);
+				self.hook_out = 1;
+			}
+			self.menu_count = 30;
+			self.current_menu = 1;
+			TeamFortress_ThrowGrenade ();
+			TeamFortress_RemoveTimers ();
+			if (self.playerclass == 9) {
+				Engineer_RemoveBuildings (self);
+			}
+			self = oldself;
+			te = find (te, classname, "player");
+		}
+		round_active = 0;
+	}
+	gren = find (world, classname, "grenade");
+	while (gren)
+	{
+		gren.think = SUB_Remove;
+		gren.nextthink = (time + 0.1);
+		gren = find (gren, classname, "grenade");
+	}
+	gren = find (world, classname, "grentimer");
+	while (gren)
+	{
+		gren.think = SUB_Remove;
+		gren.nextthink = (time + 0.1);
+		gren = find (gren, classname, "grentimer");
+	}
+	te = find (world, classname, "detpack");
+	while (te)
+	{
+		if ((te.weaponmode == 1))
+		{
+			TeamFortress_SetSpeed (te.enemy);
+			dremove (te.oldenemy);
+			dremove (te.observer_list);
+		}
+		dremove (te.linked_list);
+		dremove (te);
+		te = find (te, classname, "detpack");
+	}
+	te = find (world, classname, "item_tfgoal");
+	while (te)
+	{
+		if ((te.origin != te.oldorigin))
+		{
+			oldself = spawn ();
+			oldself.enemy = te;
+			oldself.weapon = 3;
+			oldself.nextthink = (time + 0.2);
+			oldself.think = ReturnItem;
+		}
+		te = find (te, classname, "item_tfgoal");
+	}
+	te = find (world, classname, "item_ball");
+	while (te)
+	{
+		if ((te.origin != te.oldorigin))
+		{
+			te.nextthink = (time + 0.3);
+			te.think = ball_reset;
+		}
+		te = find (te, classname, "item_ball");
+	}
+	te = find (world, classname, "ammobox");
+	while (te)
+	{
+		te.nextthink = (time + 0.3);
+		te.think = TeamFortress_AmmoboxThink;
+		te = find (te, classname, "ammobox");
+	}
+	te = find (world, classname, "round");
+	st = infokey (world, "count");
+	fl = stof (st);
+	if ((fl < 3) || (fl > 20))
+	{
+		fl = enter;
+	}
+	te.cnt2 = 10;
+	st = infokey (world, "round_time");
+	te.cnt = stof (st);
+	quad_winner = CheckWinningTeam();	
+	if (rounds > 1) {
+//		lightstyle (0, "e");
+		localcmd("serverinfo status Countdown\n");
+		te.think = QuadRoundBegin;
+		te.nextthink = (time + 0.01);
+	}
+	else {
+//		lightstyle (0, "e");
+		localcmd("serverinfo status Countdown\n");
+		te.think = QuadRoundInit;
+		te.nextthink = (time + 1); 
+	}
+};
+
+void () EndRound = {
+	if (infokey(world, "quadmode") == "on") {
+		if (infokey(world,"status") != "Countdown" && infokey(world,"status") != "Standby") {
+			if (rounds > 1) {
+				bprint (2, "ROUND TIME OVER\nNext round begins in 10 seconds\n");
+//					lightstyle (0, "e");
+					localcmd("serverinfo status Countdown\n");
+					self.think = QuadRoundOver;
+					self.nextthink = (time + 0.1);
+			}
+			else if (rounds == 1) {
+				StartQuadRound();
+			}
+		}
+	}
+};

--- a/quadmode.qc
+++ b/quadmode.qc
@@ -126,10 +126,15 @@ void () QuadRoundBegin = {
 		te.solid = 4;
 		te = find(te, classname, "func_breakable");
 	}
+	cb_prematch = 0;
+
 	te = find(world, classname, "player");
 	while (te != world) {
 		oldself = self;
 		self = te;
+		self.takedamage = 2;
+		self.solid = 3;
+		self.movetype = 3;
 		TeamFortress_RemoveTimers();
 		setspawnparms(self);
 		PutClientInServer();
@@ -178,19 +183,6 @@ void () QuadRoundInit = {
 	self.cnt2 = (self.cnt2 - 1);
 	if (self.cnt2 == 2)
 		round_over = 2;
-	if (self.cnt2 == 1)	{
-		p = find(world, classname, "player");
-		while (p != world) {
-			if (p.netname != "") {
-				p.takedamage = 0;
-				p.solid = 0;
-				p.movetype = 0;
-				p.modelindex = 0;
-				p.model = string_null;
-			}
-			p = find(p, classname, "player");
-		}
-	}
 	else {
 		if (!self.cnt2)	{
 			self.nextthink = (time + 0.1);
@@ -233,8 +225,20 @@ void () StartQuadRound =
 	local entity p;
 
 	lightstyle(0, "m");
-	cb_prematch = 0;
+	cb_prematch = 1;
     cease_fire = 0;
+
+	p = find(world, classname, "player");
+	while (p != world) {
+		if (p.netname != "") {
+			p.takedamage = 0;
+			p.solid = 0;
+			p.movetype = 0;
+			p.modelindex = 0;
+			p.model = string_null;
+		}
+		p = find(p, classname, "player");
+	}
 
 	if (rounds == 1) {
 		quad_winner = CheckWinningTeam();
@@ -270,18 +274,6 @@ void () StartQuadRound =
 
 	round_over = 1;
 
-	te = find(world, classname, "info_tfgoal");
-	while (te != world) {
-		if (te.netname == "blue_det" || te.netname == "red_det") {
-			te2 = self;
-			self = te;
-			self.goal_activation = 2;
-			self.solid = 1;
-			self.goal_state = 2;
-			self = te2;
-		}
-		te = find(te, classname, "info_tfgoal");
-	}
 	te = find(world, classname, "door");
 	while (te != world) {
 		te2 = self;
@@ -292,6 +284,19 @@ void () StartQuadRound =
 		te = find(te, classname, "door");
 	}
 
+	te = find(world, classname, "item_tfgoal");
+	while (te) {
+		if (te.origin != te.oldorigin) {
+			if (te.owner != world)
+					tfgoalitem_RemoveFromPlayer(te, te.owner, 1);
+			oldself = spawn();
+			oldself.enemy = te;
+			oldself.weapon = 3;
+			oldself.nextthink = (time + 0.2);
+			oldself.think = ReturnItem;
+		}
+		te = find(te, classname, "item_tfgoal");
+	}
 
 	if (round_active) {
 		te = find(world, classname, "player");
@@ -333,20 +338,7 @@ void () StartQuadRound =
 		dremove(te);
 		te = find (te, classname, "detpack");
 	}
-	te = find(world, classname, "item_tfgoal");
-	while (te) {
-		bprint(2,"Goal Name: ");
-		bprint(2,te.netname);
-		bprint(2, "\n");
-		if (te.origin != te.oldorigin) {
-			oldself = spawn();
-			oldself.enemy = te;
-			oldself.weapon = 3;
-			oldself.nextthink = (time + 0.2);
-			oldself.think = ReturnItem;
-		}
-		te = find(te, classname, "item_tfgoal");
-	}
+
 	te = find(world, classname, "round");
 	st = infokey(world, "count");
 	fl = stof(st);
@@ -357,8 +349,6 @@ void () StartQuadRound =
 	st = infokey (world, "round_time");
 	te.cnt = stof (st);
 	quad_winner = CheckWinningTeam();
-	bprint(2, ftos(rounds));
-	bprint(2, "\n");
 	localcmd("serverinfo status Standby\n");
 	if (rounds > 1) {
 		te.think = QuadRoundBegin;

--- a/qw.qc
+++ b/qw.qc
@@ -425,8 +425,6 @@ float already_chosen_map;
 float clanbattle;
 float clan_scores_dumped;
 float cb_prematch;
-float cb_prematch_time;
-float cb_ceasefire_time;
 float v_break;
 float v_ready;
 .float allowvote;

--- a/qw.qc
+++ b/qw.qc
@@ -427,12 +427,21 @@ float clan_scores_dumped;
 float cb_prematch;
 float cb_prematch_time;
 float cb_ceasefire_time;
+float v_break;
+float v_ready;
+.float allowvote;
 float game_locked;
 float team1frags;
 float team2frags;
 float team3frags;
 float team4frags;
 float last_id;
+float quadmode;
+float quad_winner;
+float rounds;
+float round_active;
+float round_over;
+float gametime;
 
 .float tf_id;
 
@@ -501,6 +510,10 @@ float pyro_type;
 
 float autokick_time;
 float autokick_kills;
+
+.float vote;
+.float bvote;
+.float is_ready;
 
 .float is_admin;
 .float admin_mode;

--- a/qw.qc
+++ b/qw.qc
@@ -442,6 +442,7 @@ float rounds;
 float round_active;
 float round_over;
 float gametime;
+float is_countdown;
 
 .float tf_id;
 

--- a/spy.qc
+++ b/spy.qc
@@ -1350,7 +1350,7 @@ void (entity spy) Spy_RemoveDisguise = {
 };
 
 void () Spy_DropBackpack = {
-    if ((cb_prematch_time + 3) > time)
+    if (cb_prematch)
         return;
 
     newmis = spawn();

--- a/tfort.qc
+++ b/tfort.qc
@@ -141,7 +141,7 @@ void (float inp) TeamFortress_ChangeClass = {
         return;
 
     if (self.playerclass != 0) {
-        if ((deathmatch != 3) && (cb_prematch_time < time))
+        if ((deathmatch != 3) && (!cb_prematch))
             return;
 
         if (self.playerclass == inp) {
@@ -252,7 +252,7 @@ void (float inp) TeamFortress_ChangeClass = {
         self.playerclass = 1 + floor(random() * 9);
     }
     if ((spot.classname == "info_player_teamspawn") &&
-        (cb_prematch_time < time)) {
+        (!cb_prematch)) {
         if (spot.items != 0) {
             te = Finditem(spot.items);
             if (te)
@@ -2463,7 +2463,7 @@ void (float Suicided) TeamFortress_SetupRespawn = {
     else
         restime = 0;
 
-    if (cb_prematch_time < time) {
+    if (!cb_prematch) {
         if (Suicided) {
             if (self.lives > 0)
                 self.lives = self.lives - 1;

--- a/tforthlp.qc
+++ b/tforthlp.qc
@@ -179,8 +179,8 @@ void () TeamFortress_MOTD = {
         TeamFortress_Alias("detdispenser", TF_ENGINEER_DETDISP, 0);
     } else if (self.motd == 130) {
         stuffcmd(self, "is_aliased\n");
-        TeamFortress_Alias ("ready", TF_PLAYERREADY, 0);
-        TeamFortress_Alias ("break", TF_PLAYERBREAK, 0);
+        TeamFortress_Alias ("ready", TF_PLAYER_READY, 0);
+        TeamFortress_Alias ("notready", TF_PLAYER_NOT_READY, 0);
     } else if (self.motd == 400 && self.team_no == 0) {
         Menu_Team(1);
     }

--- a/tforthlp.qc
+++ b/tforthlp.qc
@@ -179,6 +179,8 @@ void () TeamFortress_MOTD = {
         TeamFortress_Alias("detdispenser", TF_ENGINEER_DETDISP, 0);
     } else if (self.motd == 130) {
         stuffcmd(self, "is_aliased\n");
+        TeamFortress_Alias ("ready", TF_PLAYERREADY, 0);
+        TeamFortress_Alias ("break", TF_PLAYERBREAK, 0);
     } else if (self.motd == 400 && self.team_no == 0) {
         Menu_Team(1);
     }

--- a/tfortmap.qc
+++ b/tfortmap.qc
@@ -2782,7 +2782,7 @@ void (entity P) ForceRespawn = {
     if (self.playerclass != 0)
         spawn_tdeath(self.origin, self);
     if ((spot.classname == "info_player_teamspawn") &&
-            (cb_prematch_time < time)) {
+            (!cb_prematch)) {
         if (spot.items != 0) {
             te = Finditem(spot.items);
             if (te) {

--- a/weapons.qc
+++ b/weapons.qc
@@ -106,6 +106,9 @@ void () TranquiliserTimer;
 
 void () TeamFortress_CTF_FlagInfo;
 void () ClanMode;
+void () QuadMode;
+void () EndQuadRound;
+void () PlayerReady;
 
 void () W_Precache = {
     precache_sound("weapons/r_exp3.wav");

--- a/weapons.qc
+++ b/weapons.qc
@@ -109,6 +109,7 @@ void () ClanMode;
 void () QuadMode;
 void () EndQuadRound;
 void () PlayerReady;
+void () StartTimer;
 
 void () W_Precache = {
     precache_sound("weapons/r_exp3.wav");
@@ -2532,10 +2533,10 @@ void () DeadImpulses = {
     else if ((self.impulse >= TF_CHANGEPC_SCOUT) && (self.impulse <= TF_CHANGEPC_RANDOM)) {
         TeamFortress_ChangeClass(self.impulse - TF_CHANGEPC_SCOUT + 1);
     } else if ((self.playerclass != 0) && (self.impulse == TF_CHANGETEAM)
-               && (deathmatch == 3) && (cb_prematch_time < time)) {
+               && (deathmatch == 3) && (!cb_prematch)) {
         Menu_Team(0);
     } else if ((self.playerclass != 0) && (self.impulse == TF_CHANGECLASS)
-               && (deathmatch == 3) && (cb_prematch_time < time)) {
+               && (deathmatch == 3) && (!cb_prematch)) {
         Menu_Class(0);
     } else if (self.is_admin) {
         if (self.impulse == 193)
@@ -2557,6 +2558,9 @@ void () DeadImpulses = {
         else if (self.impulse == 239) {
             self.current_menu_page = 1;
             Menu_Admin();
+        }
+        else if (self.impulse == TF_FORCESTARTMATCH) {
+            StartTimer();
         }
     }
     if (self.impulse == TF_HELP_MAP)
@@ -2627,6 +2631,18 @@ void () DeadImpulses = {
         sprint(self, PRINT_HIGH, "Aliases checked\n");
         self.got_aliases = 1;
         self.impulse = 0;
+    }
+    if (self.impulse == TF_PLAYERREADY) {
+        if (clanbattle == 1) {
+            if (!cb_prematch) {
+                sprint (self, 2, "Match already in progress...\n");
+                self.impulse = 0;
+                return;
+            }
+            PlayerReady();                                                                                                                                              self.impulse = 0;
+            self.impulse = 0;
+            return;
+        }
     }
 };
 

--- a/weapons.qc
+++ b/weapons.qc
@@ -2996,6 +2996,8 @@ void () DeadImpulses = {
             Admin_ListIPs();
         else if (self.impulse == 207)
             ClanMode();
+        else if (self.impulse == 208)
+            QuadMode();
         else if (self.impulse == 239) {
             self.current_menu_page = 1;
             Menu_Admin();

--- a/weapons.qc
+++ b/weapons.qc
@@ -109,6 +109,7 @@ void () ClanMode;
 void () QuadMode;
 void () EndQuadRound;
 void () PlayerReady;
+void () PlayerNotReady;
 void () StartTimer;
 
 void () W_Precache = {
@@ -2632,7 +2633,7 @@ void () DeadImpulses = {
         self.got_aliases = 1;
         self.impulse = 0;
     }
-    if (self.impulse == TF_PLAYERREADY) {
+    if (self.impulse == TF_PLAYER_READY) {
         if (clanbattle == 1) {
             if (!cb_prematch) {
                 sprint (self, 2, "Match already in progress...\n");
@@ -2640,6 +2641,18 @@ void () DeadImpulses = {
                 return;
             }
             PlayerReady();                                                                                                                                              self.impulse = 0;
+            self.impulse = 0;
+            return;
+        }
+    }
+    else if (self.impulse == TF_PLAYER_NOT_READY) {
+        if (clanbattle == 1) {
+            if (!cb_prematch) {
+                sprint (self, 2, "Match already in progress...\n");
+                self.impulse = 0;
+                return;
+            }
+            PlayerNotReady();                                                                                                                                              self.impulse = 0;
             self.impulse = 0;
             return;
         }

--- a/weapons.qc
+++ b/weapons.qc
@@ -110,6 +110,7 @@ void () QuadMode;
 void () EndQuadRound;
 void () PlayerReady;
 void () PlayerNotReady;
+void () Broadcast_Players_NotReady;
 void () StartTimer;
 
 void () W_Precache = {
@@ -2560,9 +2561,10 @@ void () DeadImpulses = {
             self.current_menu_page = 1;
             Menu_Admin();
         }
-        else if (self.impulse == TF_FORCESTARTMATCH) {
+        else if (self.impulse == TF_FORCESTARTMATCH)
             StartTimer();
-        }
+        else if (self.impulse == TF_READYSTATUS)
+            Broadcast_Players_NotReady();
     }
     if (self.impulse == TF_HELP_MAP)
         TeamFortress_HelpMap();

--- a/world.qc
+++ b/world.qc
@@ -340,7 +340,7 @@ void () InitBodyQue = {
 };
 
 void (entity ent) CopyToBodyQue = {
-    if ((cb_prematch_time + 3) > time)
+    if (cb_prematch)
         return;
 
     bodyque_head.angles = ent.angles;


### PR DESCRIPTION
**Changes**
No more prematch time limit, prematch will go on until everyone is ready or admin forces a match start.
Clock should be in sync when match actually starts (tested with the original ezquake client)

**For players:**
_/ready_ - makes you ready to start
_/notready_ (or _/ready_ again) - makes you not ready anymore

**For admins:**
_/clan_ - sets up clan mode, you have to restart the map
_/quadmode_ - same, but for quad mode
_/startmatch_ - forces the match to start, ignoring if players are ready or not. The same behaviour will happen if _/ceasefire_ is used twice.
_/readystatus_ - broadcasts a list of players who are not ready

**Quadmode:**
Right now it's following brazilian ruleset, we may change it and make it configurable.
Two rounds of 10 minutes with a short intermission in the middle (players can't move, flags are returned to base).

In the second round, if the attacking team captures more flags than the team that was attacking on the first round, the match will end automatically even if the timelimit is not reached.