### PR TITLE
the setsize call seems to help

### DIFF
--- a/tfortmap.qc
+++ b/tfortmap.qc
@@ -652,6 +652,7 @@ void (entity Goal) RestoreGoal = {
         Goal.goal_state = 2;
         if (Goal.mdl != string_null) {
             setmodel(Goal, Goal.mdl);
+            setsize(Goal, Goal.goal_min, Goal.goal_max);
         }
         if (Goal.model == "progs/tf_flag.mdl" || Goal.model == "progs/tf_stan.mdl") {
             Goal.effects = Goal.effects | EF_DIMLIGHT;


### PR DESCRIPTION
Spoike: conceptually its goal is to set .model (and thus also needs to set .modelindex otherwise the client won't see the change), it MAY also change mins/maxs (although what it changes it to is always annoying), it then relinks the entity (which sets .size, and the exact results also depend upon .solid)
[19:24] Spoike: if its 'until player-specific-change', then the bug itself is not in the setmodel builtin.
[19:26] Spoike: whether setmodel changes mins/maxs depends upon the game. for quakeworld, it'll do it ONLY if the extension is .bsp (dedicated servers don't load mdls, and don't try according to the file extension in setmodel)
[19:28] Spoike: (vanilla netquake doesn't check extensions, but will always use +/- 16 for the size - a fact that also breaks culling, which means that many nq engines changed the value to some unguessable value that changes according to replacement models, that then causes those entities to collide against the world differently)
[19:28] Spoike: so the general rule is to ALWAYS use setsize after setmodel, unless the model is KNOWN to be a .bsp
[19:29] Spoike: because frankly its the only way to get reliable, reproducable, and correct behaviour...