### PR TITLE
Statusbar flaginfo location

### DIFF
--- a/qw.qc
+++ b/qw.qc
@@ -332,6 +332,7 @@ float item_list_bit;            // Global, used to determine what the bit of
 
 .float delay_time;              // For delayed goal results
 .float dont_do_triggerwork;
+.float track_goal;              // Track this info_goal in the statusbar
 
 // Abbreviations for the above
 .float g_a;                     // goal_activation

--- a/status.qc
+++ b/status.qc
@@ -21,6 +21,7 @@ string(entity pl) BuildingToString;
 string(float pc) TeamFortress_GetClassName;
 entity(float ino) Finditem;
 void () tfgoalitem_droptouch;
+void () tfgoalitem_dropthink;
 
 string (float class) CF_GetRandomClassTip {
     local string tiptype = "";
@@ -627,7 +628,9 @@ string (entity Player, entity Item, float teamno) GetItemStatus = {
                     if(Item.think != tfgoalitem_droptouch) {
                         //tfgoalitem_dropthink is the normal countdown
                     //    st = strcat(st, Q"\s: Dropped \s", ftos(rint(Item.nextthink - time)));
-                        st = strcat(st, Q"\s: Return: \s", ftos(rint(Item.bubble_count - time)));
+                        st = strcat(st, Q"\s: Returning: \s", ftos(rint(Item.bubble_count - time)));
+                    } else {
+                        st = strcat(st, Q"\s: Dropped\s");
                     }
                 //}
                 
@@ -715,7 +718,7 @@ void (entity pl) RefreshStatusBar = {
                 {
                     if(number_of_teams < 3) {
                         ct = strcat(ct, strpadr(GetItemStatus(pl, te, t),40),"\n");
-                        if(te.think != tfgoalitem_droptouch) {
+                        if(te.think == tfgoalitem_dropthink && te.flags & FL_ONGROUND) {
                             ct = strcat(ct, strpadr(strcat("\s Location: \s", getLocationName(te.origin)),40));
                         }
                         i += 1;

--- a/status.qc
+++ b/status.qc
@@ -612,7 +612,7 @@ string (entity Player, entity Item, float teamno) GetItemStatus = {
             //When the item is thrown, there is a touch think with a pad of 4.25s before the normal timer kicks in
             if((Item.nextthink - time) >= 0) {
                 if(Item.think != tfgoalitem_droptouch) {
-                    st = strcat(st, Q"\s: Returning: \s", ftos(rint(Item.bubble_count - time)));
+                    st = strcat(st, Q"\s: Return: \s", ftos(rint(Item.bubble_count - time)));
                 } else {
                     st = strcat(st, Q"\s: Dropped\s");
                 }
@@ -705,7 +705,11 @@ void (entity pl) RefreshStatusBar = {
                         }
                         i += 1;
                     } else {
-                        ct = strcat(ct, strpadr(GetItemStatus(pl, te, t),40));
+                        if((te.think == tfgoalitem_dropthink || te.think == tfgoalitem_remove) && !te.owner) {
+                            ct = strcat(ct, strpadr(strcat(GetItemStatus(pl, te, t),"\s: \s", getLocationName(te.origin)),40));
+                        } else {
+                            ct = strcat(ct, strpadr(GetItemStatus(pl, te, t),40));
+                        }
                     }
                 }
                 ct = strcat(ct, "\n");

--- a/status.qc
+++ b/status.qc
@@ -609,13 +609,27 @@ string (entity Player, entity Item, float teamno) GetItemStatus = {
         if (Item.origin != Item.oldorigin) {
             //When the item is thrown, there is a touch think with a pad of 4.25s before the normal timer kicks in
             if((Item.nextthink - time) >= 0) {
-                //    st = strcat(st, Q"\s: Dropped \s", ftos(rint(Item.pausetime + Item.nextthink - time)));
-                    st = strcat(st, Q"\s: Dropped: \s", getLocationName(Item.origin));
-                if(Item.think != tfgoalitem_droptouch) {
-                    //tfgoalitem_dropthink is the normal countdown
-                //    st = strcat(st, Q"\s: Dropped \s", ftos(rint(Item.nextthink - time)));
-                    st = strcat(st, Q"\s: Return: \s", ftos(rint(Item.bubble_count - time)));
-                }
+                //if(number_of_teams < 3) {
+                //    if(Item.think != tfgoalitem_droptouch) {
+                //        //tfgoalitem_dropthink is the normal countdown
+                //    //    st = strcat(st, Q"\s: Dropped \s", ftos(rint(Item.nextthink - time)));
+                //        st = strpadr(strcat(st, Q"\s: Return: \s", ftos(rint(Item.bubble_count - time)), "\n"),40);
+                //        dprint(st);
+                //    } else {
+                //        st = strpadr(strcat(st, Q"\s: Dropped: \s\n"),40);
+                //    }
+                //     st = strcat(st, strpadr(strcat(Q"\s Location: \s", getLocationName(Item.origin)),40));
+                //    dprint(st);
+               
+                //} else {
+                    //    st = strcat(st, Q"\s: Dropped \s", ftos(rint(Item.pausetime + Item.nextthink - time)));
+                    //st = strcat(st, Q"\s: Dropped: \s", getLocationName(Item.origin));
+                    if(Item.think != tfgoalitem_droptouch) {
+                        //tfgoalitem_dropthink is the normal countdown
+                    //    st = strcat(st, Q"\s: Dropped \s", ftos(rint(Item.nextthink - time)));
+                        st = strcat(st, Q"\s: Return: \s", ftos(rint(Item.bubble_count - time)));
+                    }
+                //}
                 
             } else {
                 st = strcat(st, Q"\s: Returning\s NOW!");
@@ -638,7 +652,8 @@ void (entity pl) RefreshStatusBar = {
     local float height;
     local float i;
     local entity tfdet;  //info_tfdetect entity
-    local entity te;
+    local entity te, tg;
+    local string bi; //button info
     local string sbflaginfo;
     sbflaginfo = infokey(pl, "sbflaginfo");
     /* local float win, sec; */
@@ -678,7 +693,7 @@ void (entity pl) RefreshStatusBar = {
             ct = strzone("\n\n\n\n\n\n");
         } else {
             ct = "";
-
+            i = 0; // Extra newlines
             for (float t = 1; t <= number_of_teams; t++) {
                 switch (t)
                 {
@@ -698,11 +713,43 @@ void (entity pl) RefreshStatusBar = {
 
                 if (te)
                 {
-                    ct = strcat(ct, strpadr(GetItemStatus(pl, te, t),40));
+                    if(number_of_teams < 3) {
+                        ct = strcat(ct, strpadr(GetItemStatus(pl, te, t),40),"\n");
+                        if(te.think != tfgoalitem_droptouch) {
+                            ct = strcat(ct, strpadr(strcat("\s Location: \s", getLocationName(te.origin)),40));
+                        }
+                        i += 1;
+                    } else {
+                        ct = strcat(ct, strpadr(GetItemStatus(pl, te, t),40));
+                    }
                 }
                 ct = strcat(ct, "\n");
             }
-            ct = strcat(ct, "\n\n\n");
+            tg = find(world, classname, "info_tfgoal");
+            while (tg) {
+                if (tg.track_goal && tg.goal_state == TFGS_DELAYED) {
+                    bi = "";
+                    //only do this for named goals, otherwise there's no way to distinguish them (they don't ususally have owned_by or anything)
+                    if(tg.netname) {
+                        bi = tg.netname;
+                        if(tg.team_str_moved) {
+                            bi = strcat(bi,": ", tg.team_str_moved);
+                        } else {
+                            bi = strcat(bi,": \sOffline\s");
+                        }
+                        bi = strcat(bi, " ", ftos(rint(tg.bubble_count - time)));
+                        ct = strcat(ct, strpadr(bi,40),"\n");
+                        i += 1;
+                    }
+                }
+                tg = find(tg, classname, "info_tfgoal");
+            }
+
+            
+            for (float t = 0; t < (3 - i); t++)
+                ct = strcat(ct, "\n");
+            
+            //ct = strcat(ct, "\n\n\n");
             
             ct = strzone(ct);
         }

--- a/status.qc
+++ b/status.qc
@@ -22,6 +22,7 @@ string(float pc) TeamFortress_GetClassName;
 entity(float ino) Finditem;
 void () tfgoalitem_droptouch;
 void () tfgoalitem_dropthink;
+void () tfgoalitem_remove;
 
 string (float class) CF_GetRandomClassTip {
     local string tiptype = "";
@@ -699,7 +700,7 @@ void (entity pl) RefreshStatusBar = {
                 {
                     if(number_of_teams < 4) {
                         ct = strcat(ct, strpadr(GetItemStatus(pl, te, t),40),"\n");
-                        if(te.think == tfgoalitem_dropthink && te.flags & FL_ONGROUND) {
+                        if((te.think == tfgoalitem_dropthink || te.think == tfgoalitem_remove) && !te.owner) {
                             ct = strcat(ct, strpadr(strcat("\s Location: \s", getLocationName(te.origin)),40));
                         }
                         i += 1;

--- a/status.qc
+++ b/status.qc
@@ -610,30 +610,11 @@ string (entity Player, entity Item, float teamno) GetItemStatus = {
         if (Item.origin != Item.oldorigin) {
             //When the item is thrown, there is a touch think with a pad of 4.25s before the normal timer kicks in
             if((Item.nextthink - time) >= 0) {
-                //if(number_of_teams < 3) {
-                //    if(Item.think != tfgoalitem_droptouch) {
-                //        //tfgoalitem_dropthink is the normal countdown
-                //    //    st = strcat(st, Q"\s: Dropped \s", ftos(rint(Item.nextthink - time)));
-                //        st = strpadr(strcat(st, Q"\s: Return: \s", ftos(rint(Item.bubble_count - time)), "\n"),40);
-                //        dprint(st);
-                //    } else {
-                //        st = strpadr(strcat(st, Q"\s: Dropped: \s\n"),40);
-                //    }
-                //     st = strcat(st, strpadr(strcat(Q"\s Location: \s", getLocationName(Item.origin)),40));
-                //    dprint(st);
-               
-                //} else {
-                    //    st = strcat(st, Q"\s: Dropped \s", ftos(rint(Item.pausetime + Item.nextthink - time)));
-                    //st = strcat(st, Q"\s: Dropped: \s", getLocationName(Item.origin));
-                    if(Item.think != tfgoalitem_droptouch) {
-                        //tfgoalitem_dropthink is the normal countdown
-                    //    st = strcat(st, Q"\s: Dropped \s", ftos(rint(Item.nextthink - time)));
-                        st = strcat(st, Q"\s: Returning: \s", ftos(rint(Item.bubble_count - time)));
-                    } else {
-                        st = strcat(st, Q"\s: Dropped\s");
-                    }
-                //}
-                
+                if(Item.think != tfgoalitem_droptouch) {
+                    st = strcat(st, Q"\s: Returning: \s", ftos(rint(Item.bubble_count - time)));
+                } else {
+                    st = strcat(st, Q"\s: Dropped\s");
+                }
             } else {
                 st = strcat(st, Q"\s: Returning\s NOW!");
             }
@@ -716,7 +697,7 @@ void (entity pl) RefreshStatusBar = {
 
                 if (te)
                 {
-                    if(number_of_teams < 3) {
+                    if(number_of_teams < 4) {
                         ct = strcat(ct, strpadr(GetItemStatus(pl, te, t),40),"\n");
                         if(te.think == tfgoalitem_dropthink && te.flags & FL_ONGROUND) {
                             ct = strcat(ct, strpadr(strcat("\s Location: \s", getLocationName(te.origin)),40));
@@ -730,7 +711,7 @@ void (entity pl) RefreshStatusBar = {
             }
             tg = find(world, classname, "info_tfgoal");
             while (tg) {
-                if (tg.track_goal && tg.goal_state == TFGS_DELAYED) {
+                if (tg.track_goal && tg.goal_state == TFGS_DELAYED && i < 3) {
                     bi = "";
                     //only do this for named goals, otherwise there's no way to distinguish them (they don't ususally have owned_by or anything)
                     if(tg.netname) {

--- a/tfortmap.qc
+++ b/tfortmap.qc
@@ -588,7 +588,7 @@ void (entity AD) ParseTFDetect = {
 entity(float ino) Finditem =
 {
     local entity tg;
-    local string st;
+    //local string st;
 
     tg = find(world, classname, "item_tfgoal");
     while (tg) {
@@ -596,10 +596,10 @@ entity(float ino) Finditem =
             return (tg);
         tg = find(tg, classname, "item_tfgoal");
     }
-    dprint("Could not find an item with a goal_no of ");
-    st = ftos(ino);
-    dprint(st);
-    dprint(".\n");
+    //dprint("Could not find an item with a goal_no of ");
+    //st = ftos(ino);
+    //dprint(st);
+    //dprint(".\n");
     return world;
 };
 
@@ -2844,7 +2844,6 @@ void (entity P) ForceRespawn = {
 void () DropGoalItems = {
     local entity te, search;
     
-    dprint("DropGoalItems requested");
     newmis = spawn();
     makevectors(self.v_angle);
     v_forward = normalize(v_forward) * 64;
@@ -2893,15 +2892,15 @@ void () DropGoalItems = {
                     } else {
                         Status_Print(search, "\n\n\n", "The enemy dropped your flag!");
                     }
-                    search = find(search, classname, "player");
-                    if (te.owned_by > 0) {
+                    if (te.owned_by) {
                         if (te.netname_team_drop && te.netname_non_team_drop && search.team_no == te.owned_by) {
-                            sprint(PRINT_HIGH, self.netname, te.netname_team_drop);
+                            sprint(search, PRINT_HIGH, self.netname, te.netname_team_drop);
                         } 
                         if (te.netname_team_drop && te.netname_non_team_drop && search.team_no != te.owned_by) {
-                            sprint(PRINT_HIGH, self.netname, te.netname_non_team_drop);
+                            sprint(search, PRINT_HIGH, self.netname, te.netname_non_team_drop);
                         } 
-                   }
+                    }
+                    search = find(search, classname, "player");
                 }
             }
         }

--- a/tfortmap.qc
+++ b/tfortmap.qc
@@ -1667,6 +1667,7 @@ void (entity Goal, entity AP, float addb) DoResults = {
         te.owner = AP;
         te.enemy = Goal;
         te.weapon = addb;
+        Goal.bubble_count = time + Goal.delay_time;
         return;
     }
 
@@ -2842,7 +2843,8 @@ void (entity P) ForceRespawn = {
 
 void () DropGoalItems = {
     local entity te, search;
-
+    
+    dprint("DropGoalItems requested");
     newmis = spawn();
     makevectors(self.v_angle);
     v_forward = normalize(v_forward) * 64;


### PR DESCRIPTION
StatusBar FlagInfo changes:
- For maps with 3 teams or less, uses 2 lines to report flag status and location
- Location is only displayed after a second or so of being dropped, allowing the flag to be passed around secretly
- For info_tfgoals with track_goal set to 1, will display additional countdown if they're in their delayed state. netname must be set, team_str_moved can optionally be used as the "offilne" status string.
It will only appear if there's room in the status bar and disappear once the countdown has finished.
- Flagdrop message fix (was throwing errors in server console).