### PR TITLE
Hud more options

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -259,11 +259,12 @@ var FO_Hud_Panel Hud_Panels[] = {
     {"grentimerpanel","Grenade Timer",'0 0','50 26',1,0,1,0, drawGrenTimerPanel, {return "";}}
 };
 
-
-
+#define FOCMD_AUTOHOP "fo_autohop"
+#define FOCMD_GRENTIMER "fo_grentimer"
 
 typedef struct {
     float Autohop;
+    float Grentimer;
 } FO_Settings;
 FO_Settings Settings;
 

--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -195,8 +195,8 @@ void(string panelid, float display, string text, string icon) drawSpecial = {
 };
 void(string panelid, float display, string text, string icon) drawGrenTimerPanel = {
     local float timeleft;
-    if (display || fo_hud_editor)
-    {
+    local float timercount = 0;
+    if (display) {
         GetDrawPanel(panelid);
         float Scale = DrawPanel.Scale;
         float TextScale = DrawPanel.TextScale;
@@ -216,14 +216,19 @@ void(string panelid, float display, string text, string icon) drawGrenTimerPanel
                         FO_Hud_Grentimers[FO_Hud_Grentimers.length - 1].icon_index = 0;
                     continue;
                 }
-                DrawPanel.Position = DrawPanel.Position + [0, 24 * DrawPanel.Scale];
                 if(i) {
                     DrawPanel.Scale = Scale * 0.8;
                     DrawPanel.TextScale = TextScale * 0.8;
                 }
                 Hud_DrawPanelLMP(panelid, ftos(timeleft), HudIcons[FO_Hud_Grentimers[i].icon_index].icon);
+                DrawPanel.Position = DrawPanel.Position + [0, 24 * DrawPanel.Scale];
+                timercount++;
             }
         }
+    }
+    if(fo_hud_editor && (!display || !timercount)) {
+        GetDrawPanel(panelid);
+        Hud_DrawPanelLMP(panelid, "0", ICON_GREN1);
     }
 };
 

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -96,8 +96,10 @@ void() CSQC_Parse_Event = {
             break;
         case MSG_GRENPRIMED:
             float grentype = readfloat();
-            print("Grenade Primed type ", ftos(grentype) ,"\n");
             AddGrenTimer(grentype);
+            if(Settings.Grentimer == 1) {
+                localcmd("play grentimer.wav\n");
+            } 
             break;
     }
 }

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -98,6 +98,7 @@ void() CSQC_Parse_Event = {
             float grentype = readfloat();
             AddGrenTimer(grentype);
             if(Settings.Grentimer == 1) {
+                print("playing grentimer!\n");
                 localcmd("play grentimer.wav\n");
             } 
             break;

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -23,6 +23,7 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
 	registercommand("fo_hud_reload");
 	registercommand("fo_hud_reset");
 	registercommand("fo_autohop");
+	registercommand(FOCMD_GRENTIMER);
 
 	FO_Hud_Editor_LoadSettings();
 	FO_LoadSettings();
@@ -69,27 +70,35 @@ noref float(string cmd) CSQC_ConsoleCommand = {
 			FO_Hud_Editor_LoadDefaultSettings();
 			break;
 		case "fo_autohop":
-			val = stof(argv(1));
-			if (val == 1)
-			{
-				Settings.Autohop = 1;
-				print("auto bunnyhop has been enabled\n");
+			if(!argv(1)) {
+			    print("Autohop is ",Settings.Autohop?"on":"off","\n");
+			} else {
+			    val = stof(argv(1));
+			    if (val == 1)
+			    {
+				    Settings.Autohop = 1;
+				    print("auto bunnyhop has been enabled\n");
+			    }
+			    else if (val == 0)
+			    {
+				    Settings.Autohop = 0;
+				    print("auto bunnyhop has been disabled\n");
+			    }
+			    FO_WriteSettings();
 			}
-			else if (val == 0)
-			{
-				Settings.Autohop = 0;
-				print("auto bunnyhop has been disabled\n");
-			}
-			FO_WriteSettings();
 			break;
 		case FOCMD_GRENTIMER:
-			val = stof(argv(1));
-			if(val == 1) {
-			    Settings.Grentimer = 1;
-			} else if(val == 0) {
-			    Settings.Grentimer = 0;
+			if(!argv(1)) {
+			    print("Client-side Grenade timer is ",Settings.Grentimer?"on":"off","\n");
+			} else {
+			    val = stof(argv(1));
+			    if(val == 1) {
+				Settings.Grentimer = 1;
+			    } else if(val == 0) {
+				Settings.Grentimer = 0;
+			    }
+			    FO_WriteSettings();
 			}
-			FO_WriteSettings();
 			break;
     }	
     return FALSE;

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -81,6 +81,15 @@ noref float(string cmd) CSQC_ConsoleCommand = {
 			}
 			FO_WriteSettings();
 			break;
+		case FOCMD_GRENTIMER:
+			val = stof(argv(1));
+			if(val == 1) {
+			    Settings.Grentimer = 1;
+			} else if(val == 0) {
+			    Settings.Grentimer = 0;
+			}
+			FO_WriteSettings();
+			break;
     }	
     return FALSE;
 };

--- a/csqc/settings.qc
+++ b/csqc/settings.qc
@@ -3,8 +3,8 @@ void FO_WriteSettings()
     // this overwrites
     float filehandle;
     filehandle = fopen(FO_CONFIG_PATH, FILE_WRITE);
-    string line = FormatCfgString("", "fo_autohop", ftos(Settings.Autohop));
-
+    string line = FormatCfgString("", FOCMD_AUTOHOP, ftos(Settings.Autohop));
+    line = FormatCfgString(line, FOCMD_GRENTIMER, ftos(Settings.Grentimer));
     fputs(filehandle, line);
     fclose(filehandle);
 }
@@ -41,8 +41,11 @@ void FO_LoadSettings()
 
                 switch(field)
                 {
-                    case "fo_autohop":
+                    case FOCMD_AUTOHOP:
                         Settings.Autohop = stof(val);
+                        break;
+                    case FOCMD_GRENTIMER:
+                        Settings.Grentimer = stof(val);
                         break;
                 }
             }

--- a/menu/options_basic.qc
+++ b/menu/options_basic.qc
@@ -48,6 +48,8 @@ class options_basic : mitem_exmenu
 			return (autocvar_m_pitch<0)?"1":"0";
 		if (key == "cl_run")
 			return (stof(super::get("cl_forwardspeed")) > 200)?"1":"0";
+		//if (key == "fo_grentimer")
+		//	return getplayerkeyvalue(player_localnum, "nt");
 		return super::get(key);
 	};
 	virtual void(string key, string newval) set =
@@ -124,6 +126,8 @@ nonstatic void(mitem_desktop desktop) M_Options_Basic =
 	fr.add(menuitemslider_spawn(_("Brightness"),		dp("v_brightness", "brightness"),'0.0 0.5 0.1', '280 8'),	fl, [0, pos], [0, 8]); pos += 8;
 	fr.add(menuitemslider_spawn(_("Crosshair"),		"crosshair", 			'0.0 19 1', 	'280 8'),	fl, [0, pos], [0, 8]); pos += 8;
 	fr.add(menuitemcheck_spawn (_("Show Speed"),		"show_speed", 					'280 8'),	fl, [0, pos], [0, 8]); pos += 8;
+    //pos += 8;
+	//fr.add(menuitemcheck_spawn (_("Grenade Timer"),		"fo_grentimer", 					'280 8'),	fl, [0, pos], [0, 8]); pos += 8;
 	//fr.add(menuitemslider_spawn(_("TF Status Bar"),		"crosshair", 			'0.0 19 1', 	'280 8'),	fl, [0, pos], [0, 8]); pos += 8;
 	//fr.add(menuitemslider_spawn(_("TF Flag Info"),		"crosshair", 			'0.0 19 1', 	'280 8'),	fl, [0, pos], [0, 8]); pos += 8;
 	

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -898,6 +898,7 @@ void (float inp) TeamFortress_PrimeGrenade = {
 
         RemoveGrenadeTimers();
 
+        local float csqcactive = infokeyf(self, INFOKEY_P_CSQCACTIVE);
         local float notimers = stof(infokey(self, "nt"));
         if (grentimers && notimers != 1) {
             timer = spawn();
@@ -909,10 +910,9 @@ void (float inp) TeamFortress_PrimeGrenade = {
             if (!notimers) {
                 stuffcmd(self, "play grentimer\n");
             }
-            local float csqcactive = infokeyf(self, INFOKEY_P_CSQCACTIVE);
-            if (csqcactive) {
-                UpdateClientGrenadePrimed(self, gtype);
-            }
+        }
+        if (grentimers && csqcactive) {
+            UpdateClientGrenadePrimed(self, gtype);
         }
     }
 


### PR DESCRIPTION
So now the server-side grentimer is still controlled by `setinfo nt 0/1` and client-side by the `fo_grentimer 0/1` command. Might still need to review this for use with the menu though.