### PR TITLE
even better class change logic

### DIFF
--- a/ssqc/commands.qc
+++ b/ssqc/commands.qc
@@ -379,28 +379,23 @@ float (string arg1, string arg2, string arg3) ParseCmds = {
                 override_mapclasses = CF_GetSetting("omc", "override_mapclasses", "off");
                 
                 // close menu if selected class is current class
-                if ((newclass == self.playerclass && !(self.tfstate & TFSTATE_RANDOMPC)) || (newclass == 10 && (self.tfstate & TFSTATE_RANDOMPC))) {
-                    sprint(self, PRINT_HIGH, "You're already playing that class!\n");
+                if (newclass == self.nextpc) {
+                    sprint(self, PRINT_HIGH, "You're already going to play that class!\n");
                     break;
                 }
                 
                 // keep showing menu if class is invalid
-                if (newclass < 1 || newclass > 10 || (!IsLegalClass(newclass) && !override_mapclasses) || CF_ClassIsRestricted(self.team_no, newclass)) {                    
+                if (newclass < 1 || newclass > 10 || (!IsLegalClass(newclass) && !override_mapclasses) || (self.playerclass != newclass && CF_ClassIsRestricted(self.team_no, newclass))) {                    
                     sprint(self, PRINT_HIGH, "Invalid class for this team!\n");
                     Menu_Class(0);
                     break;
                 }
 
                 // don't try to change class if class is forbidden
-                if ((!IsLegalClass(newclass) && !override_mapclasses) || CF_GetClassRestriction(self.team_no, newclass) == -1) {
+                if ((!IsLegalClass(newclass) && !override_mapclasses) || (self.playerclass != newclass && CF_GetClassRestriction(self.team_no, newclass) == -1)) {
                     sprint(self, PRINT_HIGH, "Forbidden class for this team!\n");
                     break;
                 }
-
-                // close menu if selected class is current class
-                //if (self.playerclass == newclass || (newclass == 10 && (self.tfstate & TFSTATE_RANDOMPC))) {
-                //    break;
-                //}
 
                 TeamFortress_ChangeClass(newclass);
             } else {

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -171,7 +171,7 @@ void (float inp) TeamFortress_ChangeClass = {
                        "The spy class has been disabled on the server by the administrator\n");
                 return;
             }
-            if (CF_ClassIsRestricted(self.team_no, inp)) {
+            if (self.playerclass != inp && CF_ClassIsRestricted(self.team_no, inp)) {
                 sprint(self, PRINT_HIGH,
                        "Your team already has enough of that class\n");
                 return;


### PR DESCRIPTION
internally, classes seem to be limited to the current number of players on the team, so switching soldier -> demo -> soldier before dying would come up as restricted as it would estimate 2 future soldiers (current class + target class) for only 1 team member. Exclude check now.