### PR TITLE
creating huetf preset, moving round_delay_time from quadmode to default

### DIFF
--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -662,6 +662,9 @@ void () DecodeLevelParms = {
             vote_threshold = 0.5;
         }
         
+        //default round interval for quadmode (seconds)
+        localcmd ("localinfo round_delay_time 30\n");
+
         // enforces login
         loginRequired = CF_GetSetting("loginrequired", "logreq", "0");
 
@@ -852,6 +855,47 @@ void () DecodeLevelParms = {
             solid_nailgren = TRUE;
         }
 
+        st = infokey(world, "huetf");
+        if (st == "on") {
+            server_huetf = TRUE;
+            impulse_queue = TRUE;
+            chweap_wait_attfinished = FALSE;
+            flag_follow = FALSE;
+            ng_velocity = 1000;
+            ng_damage = 18;
+            sng_damage = 26;
+            old_ng_rof = TRUE;
+            scoutdash = FALSE;
+            fo_flash = FALSE;
+            nailgren_type = NGR_TYPE_DEFAULT;
+            Role_None.detpipe_limit = 7;
+            detpipe_limit_world = 7;
+            medicaura = FALSE;
+            medicnocuss = FALSE;
+            pyro_type = 1;
+            drop_grenades = FALSE;
+            drop_grenpack = FALSE;
+            drop_gren1 = 0;
+            drop_gren2 = 0;
+            cussgrentime = 19;
+            spawnfull = FALSE;
+            stockfull = FALSE;
+            stock_on_cap = FALSE;
+            stock_reload = FALSE;
+            classtips = FALSE;
+            nohitsounds = TRUE;
+            detpack_when_reloading = TRUE;
+            old_hp_armor = TRUE;
+            server_sbflaginfo = FALSE;
+            solid_detpack = TRUE;
+            walls_block_emp = FALSE;
+            grentimers = FALSE;
+            Role_None.gren2_limits[1] = 3;
+            Role_None.gren2_limits[3] = 2;
+            Role_None.gren2_limits[4] = 4;
+            Role_None.gren2_limits[5] = 3;
+            Role_None.gren2_limits[8] = 3;
+        }
     }
 
     if (parm11)

--- a/ssqc/commands.qc
+++ b/ssqc/commands.qc
@@ -53,7 +53,6 @@ void () QuadMode =
     localcmd ("localinfo rounds 2\n");
     localcmd ("timelimit 0\n");
     localcmd ("localinfo round_time 10\n");
-    localcmd ("localinfo round_delay_time 30\n");
     localcmd ("localinfo teamfrags on\n");
     localcmd ("localinfo fullteamscore off\n");
     localcmd ("fraglimit 0\n");
@@ -71,6 +70,7 @@ void () ClanMode =
     localcmd ("localinfo rd 0\n"); 
     localcmd ("localinfo votemode 0\n"); 
     localcmd ("localinfo vote_style 2\n"); 
+    localcmd ("localinfo rounds 0\n");
     localcmd ("exec fo_clanmode.cfg\n");
     bprint(PRINT_HIGH, "Clan Mode set to on\n");
 	bprint(PRINT_HIGH, "Map Restart needed to take effect!\n");

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -559,6 +559,7 @@ float sniperreloadpercent;
 float buildstatus;
 float server_default;
 float server_faithful;
+float server_huetf;
 
 float old_spanner;
 float old_dispenser;

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -724,6 +724,9 @@ void () TeamFortress_ShowTF = {
     } else if (server_default) {
         sprint(self, PRINT_HIGH, "\nThis server is running default FortressOne Server settings.\n");
     }
+    else if (server_huetf) {
+        sprint(self, PRINT_HIGH, "\nThis server is running HueTF FortressOne Server settings.\n");
+    }
 };
 
 void () TeamFortress_GrenadePrimed;


### PR DESCRIPTION
Created a preset for HueTF rules, so we can move away from setting localinfos via cfg files.
Also moved round_delay_time away from "quadmode" command due to inconsistencies (eg: we set round_delay_time to 10 on server config files, however when someone activates quadmode by hand it gets reset)