### PR TITLE
Allow "on" value for setinfo ec as well

### DIFF
--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -3118,13 +3118,9 @@ void (entity pl, float fr) TF_AddFrags = {
 };
 
 void (entity p) TeamFortress_ExecClassScript = {
-    local string st;
+    local float st = FO_GetUserSetting(p, "ec", "exec_class", "off");
 
-    st = infokey(p, "ec");
-    if (st == string_null)
-        st = infokey(p, "exec_class");
-
-    if (st == "1" || st == "on") {
+    if (st) {
         if (p.playerclass == PC_SCOUT)
             stuffcmd(p, "exec scout.cfg\n");
         else if (p.playerclass == PC_SNIPER)
@@ -3147,13 +3143,9 @@ void (entity p) TeamFortress_ExecClassScript = {
 };
 
 void (entity p) TeamFortress_ExecMapScript = {
-    local string st;
+    local float st = FO_GetUserSetting(p, "em", "exec_map", "off");
 
-    st = infokey(p, "em");
-    if (st == string_null)
-        st = infokey(p, "exec_map");
-
-    if (st == "1") {
+    if (st) {
         stuffcmd(p, "exec maps/default.cfg\n");
         stuffcmd(p, "exec maps/");
         stuffcmd(p, mapname);

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -3124,7 +3124,7 @@ void (entity p) TeamFortress_ExecClassScript = {
     if (st == string_null)
         st = infokey(p, "exec_class");
 
-    if (st == "1") {
+    if (st == "1" || st == "on") {
         if (p.playerclass == PC_SCOUT)
             stuffcmd(p, "exec scout.cfg\n");
         else if (p.playerclass == PC_SNIPER)


### PR DESCRIPTION
This PR addresses #515 which allows the user to set `setinfo ec on` or `setinfo ec 1` to execute class configs, and `setinfo em on` or `setinfo em 1` to execute map configs.