### PR TITLE
Add MOVE_LAGGED to weapon traces

### DIFF
--- a/ssqc/actions.qc
+++ b/ssqc/actions.qc
@@ -288,7 +288,7 @@ void (entity pe_player, float f_type) CF_Identify = {
     v_source = pe_player.origin + v_forward * 10;
     v_source_z = pe_player.absmin_z + pe_player.size_z * 0.7;
 
-    traceline(v_source, v_source + v_forward * 2048, 0, pe_player);
+    traceline(v_source, v_source + v_forward * 2048, MOVE_LAGGED, pe_player);
     if (trace_ent != world) {
         local string s_id_string = "", s_class = "", s_name = "";
         local float f_health = 0, f_maxhealth = 0, f_armor = 0, f_maxarmor = 0, f_friendly = 0, f_fakefriendly = 0, f_sentryhealth = 0, f_maxsentryhealth = 0;

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -751,7 +751,7 @@ void (float shotcount, vector dir, vector spread) FireBullets = {
 
     ClearMultiDamage();
 
-    traceline(src, src + dir * 2048, FALSE, self);
+    traceline(src, src + dir * 2048, MOVE_LAGGED, self);
     puff_org = trace_endpos - dir * 4;
 
     while (shotcount > 0) {
@@ -760,7 +760,7 @@ void (float shotcount, vector dir, vector spread) FireBullets = {
             dir + crandom() * spread_x * v_right +
             crandom() * spread_y * v_up;
 
-        traceline(src, (src + (direction * 2048)), 0, self);
+        traceline(src, (src + (direction * 2048)), MOVE_LAGGED, self);
         if (trace_fraction != 1) {
             if (self.current_weapon != WEAP_ASSAULT_CANNON)
                 TraceAttack(4, direction);
@@ -819,7 +819,7 @@ void (vector direction, float damage) FireSniperBullet = {
 
     KickPlayer(-3, self);
 
-    traceline(src, src + direction * 4096, FALSE, self);
+    traceline(src, src + direction * 4096, MOVE_LAGGED, self);
     if (trace_fraction != 1)
         TraceAttack(damage, direction);
 
@@ -852,9 +852,9 @@ void () W_FireSniperRifle = {
     use_this = FALSE;
 
     if (old_sniperrange)
-        traceline(src, src + dir * 8092, FALSE, self);
+        traceline(src, src + dir * 8092, MOVE_LAGGED, self);
     else
-        traceline(src, src + dir * 9192, FALSE, self);
+        traceline(src, src + dir * 9192, MOVE_LAGGED, self);
     if (trace_fraction != 1)
         if (trace_ent != world)
             if (trace_ent.classname == "player")
@@ -865,9 +865,9 @@ void () W_FireSniperRifle = {
     if (!use_this) {
         dir = aim(self, 10000);
         if (old_sniperrange)
-            traceline(src, src + dir * 3072, 0, self);
+            traceline(src, src + dir * 3072, MOVE_LAGGED, self);
         else
-            traceline(src, src + dir * 9192, 0, self);
+            traceline(src, src + dir * 9192, MOVE_LAGGED, self);
     }
     deathmsg = DMSG_SNIPERRIFLE;
     dam_mult = 1;


### PR DESCRIPTION
Add MOVE_LAGGED to weapon traces so hitscan weapons can be antilagged with sv_antilag 1 without also enabling antilag for projectiles