### PR TITLE
Add distance based cuss duration option

### DIFF
--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -565,6 +565,9 @@ void () DecodeLevelParms = {
         // concussion grenade effect time [19]
         cussgrentime = CF_GetSetting("cgt", "cussgrentime", "19");
 
+        // concussion grenade effect time proportional to distance from explosion
+        distance_based_cuss_duration = CF_GetSetting("dbcd", "distance_based_cuss_duration", "off");
+
         // medic immune to concussion grenade effects [on]
         medicnocuss = CF_GetSetting("mnc", "medicnocuss", "on");
 
@@ -935,6 +938,7 @@ void () DecodeLevelParms = {
             medicaura = FALSE;
             medicnocuss = FALSE;
             project_weapons = FALSE;
+            distance_based_cuss_duration = FALSE;
             pyro_type = 1;
             drop_grenades = FALSE;
             drop_grenpack = FALSE;

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -563,6 +563,7 @@ float stock_reload;
 float classtips;
 float cussgrentime;
 float medicnocuss;
+float distance_based_cuss_duration;
 float sniperpower;
 float sniperreloadpercent;
 float buildstatus;

--- a/ssqc/scout.qc
+++ b/ssqc/scout.qc
@@ -808,6 +808,8 @@ void (entity inflictor, entity attacker, float bounce,
 
 void (entity inflictor, entity attacker, float bounce,
       entity ignore) T_RadiusBounce = {
+    local float actual_cuss_time = cussgrentime;
+    local float distance;    
     local float points;
     local entity head;
     local entity te;
@@ -818,10 +820,23 @@ void (entity inflictor, entity attacker, float bounce,
         if (head != ignore) {
             if (head.takedamage) {
                 org = head.origin + (head.mins + head.maxs) * 0.5;
-                points = 0.5 * vlen(org - inflictor.origin);
+                distance = vlen(org - inflictor.origin);
+                points = 0.5 * distance;
                 if (points < 0)
                     points = 0;
                 points = bounce - points;
+
+                if (distance_based_cuss_duration) {
+                    // Actual cuss time based on distance from max explosion radius
+                    local float fractional_distance = (1 - (distance / (bounce + 40)));
+                    if (fractional_distance <= 1 && fractional_distance > 0.80) {
+                        actual_cuss_time = cussgrentime;
+                    } else if (fractional_distance <= 0.8 && fractional_distance > 0.2) {
+                        actual_cuss_time = rint((1 - fractional_distance) * cussgrentime);
+                    } else {
+                        actual_cuss_time = rint(actual_cuss_time * 0.05);
+                    }
+                }
 
                 if ((head.classname != "building_dispenser")
                     && (head.classname != "building_sentrygun")
@@ -846,6 +861,15 @@ void (entity inflictor, entity attacker, float bounce,
                                 head = head.chain;
                                 continue;
                             }
+                        }
+
+                        if (distance_based_cuss_duration 
+                            && ((head.playerclass == PC_MEDIC) || (head.playerclass == PC_SCOUT))) {
+                            entity speedbump;
+                            speedbump = spawn();
+                            speedbump.think = CussSpeedBump;
+                            speedbump.nextthink = time + 1;
+                            speedbump.owner = head;
                         }
 
                         te = find(world, classname, "timer");
@@ -891,7 +915,7 @@ void (entity inflictor, entity attacker, float bounce,
                                 te.team_no = attacker.team_no;
                                 te.classname = "timer";
                                 te.owner = head;
-                                te.health = 40 * cussgrentime;
+                                te.health = 40 * actual_cuss_time;
                                 self.owner.is_concussed = 1;
                             }
                         }

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -658,7 +658,7 @@ void () TeamFortress_ShowTF = {
     CF_PrintSetting("Pyro max grenades type 2 (napalm)", Role_None.gren2_limits[7], "", PC_PYRO_GRENADE_MAX_2);
     CF_PrintSetting("Spy max grenades type 2 (gas)", Role_None.gren2_limits[8], "", PC_SPY_GRENADE_MAX_2);
     CF_PrintSetting("Engineer max grenades type 2 (emp)", Role_None.gren2_limits[9], "", PC_ENGINEER_GRENADE_MAX_2);
-    
+    CF_PrintSetting("Distance based cuss", distance_based_cuss_duration, "", 1);
     sprint(self, PRINT_HIGH, "Concussion effect lasts ");
     sprint(self, PRINT_HIGH, ftos(cussgrentime));
     sprint(self, PRINT_HIGH, " seconds");


### PR DESCRIPTION
Add support for cuss duration based on distance from explosion. 

Intended for use with medicnocuss = OFF, and cussgrentime = 15 (or higher than 10 as it currently is). TBC.

Rationale: 
- rewards accurate cuss throws when used offensively
- makes user have to choose between moving enemies out of the way or disabling them
- rewards good timing when used for mobility, and makes cuss jumping viable again for scout
