### PR TITLE
Experimental rocket projection

### DIFF
--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -567,6 +567,9 @@ void () DecodeLevelParms = {
         // configure max armor of heavy weapons guy [300]
         max_armor_hwguy = CF_GetSetting("mah", "max_armor_hwguy", ftos(PC_HVYWEAP_MAXARMOR));
 
+        // project rockets by player ping
+        project_rockets = CF_GetSetting("pr", "project_rockets", "on");
+
         // delay respawning by this many seconds [0]
         Role_None.respawn_delay_time = CF_GetSetting("rd", "respawn_delay", "0");
         if (Role_None.respawn_delay_time) {
@@ -895,6 +898,7 @@ void () DecodeLevelParms = {
             detpipe_limit_world = 7;
             medicaura = FALSE;
             medicnocuss = FALSE;
+            project_rockets = FALSE;
             pyro_type = 1;
             drop_grenades = FALSE;
             drop_grenpack = FALSE;

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -575,6 +575,8 @@ float old_dispenser;
 float old_hp_armor;
 float max_armor_hwguy;
 
+float project_rockets;
+
 float ng_velocity;
 float ng_damage;
 float sng_damage;

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -1106,6 +1106,30 @@ void () W_FireRocket = {
     FO_SetModel(newmis, "progs/missile.mdl");
     setsize(newmis, '0 0 0', '0 0 0');
     setorigin(newmis, self.origin + v_forward * 8 + '0 0 16');
+
+    if (project_rockets) {
+        // Project rockets player ping forward in time based on ping up to a maximum of 100ms
+        local float player_ping_s = infokeyf(self, INFOKEY_P_PING) / 1000;
+        if (player_ping_s > 0.1) {
+            player_ping_s = 0.1;
+        }
+        local float rocket_offset = player_ping_s * 450;
+        local vector projected_origin = self.origin + v_forward * (8 + rocket_offset) + '0 0 16';
+
+        local string st;
+
+        st = ftos(rocket_offset);
+        bprint4(PRINT_HIGH, "Offset : ", st, "\n");
+        
+        // Trace projectile? 
+        traceline(newmis.origin, projected_origin, MOVE_LAGGED, self);
+
+        if (trace_fraction < 1) {
+            projected_origin = trace_endpos;
+        }
+
+        setorigin(newmis, projected_origin);
+    }
 };
 
 void (entity from, float damage) LightningHit = {


### PR DESCRIPTION
- Move rockets forward player ping / 2. 
- Use a lagged trace to see if anything would be hit between standard origin and projected origin