### PR TITLE
Pyro AirblastV2 changes

### DIFF
--- a/ssqc/pyro.qc
+++ b/ssqc/pyro.qc
@@ -905,7 +905,7 @@ void () UseAirBlastV2 = {
         ent = findradius(ab_origin, abrange);
         while (ent)
         {
-            if (ent.movetype != MOVETYPE_NONE && ent != self)
+            if (ent.movetype != MOVETYPE_NONE && ent != self && CanDamage(ent,self))
             {
                 vector diameter_pos     = ab_start + aim(self,500) * vlen(ent.origin - ab_start);
                 float  distfromdiameter = vlen(ent.origin - diameter_pos);


### PR DESCRIPTION
Changes:
1. AirblastV2 push vector reverted to self.origin to avoid downward pushing grens. The 'ab_start' remains moved up 20 units for particle effect centering.
2. Airblast no longer goes through walls (using the 'CanDamage(ent,self)' function).