### PR TITLE
fix auto bunny breaking when a jump bind is used.  Fix it for normal …

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -528,6 +528,7 @@ vector thisorigin;
 vector lastorigin;
 float nextoriginupdate;
 float speed;
+float jump_counter;
 
 vector FO_Hud_Icon_Size = [24, 24, 0];
 vector FO_Hud_Icon_Font_Size = [8, 8, 0];

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -81,6 +81,7 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     player_menu_type = 0;
     is_admin = FALSE;
     grentimer_waiting = FALSE;
+    jump_counter = 0;
     num_mapvotes = 0;
     vote_selected_item = world;
     vote_selected_index = -1;
@@ -311,10 +312,18 @@ noref float(string cmd) CSQC_ConsoleCommand = {
             localcmd("cmd tracktarget\n");
             break;
         case "+aux_jump":
-            localcmd("+jump");
+        case "+jump":
+            input_buttons = input_buttons&2;
+            jump_counter = jump_counter + 1;
             break;
         case "-aux_jump":
-            localcmd("-jump");
+        case "-jump":
+            jump_counter = jump_counter - 1;
+            if (jump_counter <= 0) {
+                jump_counter = 0;
+                input_buttons &= ~2;
+            }
+            
             break;
         case "vote_addmap":
             AddVoteMap(argv(1),argv(2),argv(3),stof(argv(4)),stof(argv(5)),stof(argv(6)),TRUE);
@@ -346,7 +355,22 @@ void() CSQC_Ent_Remove = {   //the entity in question left the player's pvs, and
 };
 
 noref void CSQC_Input_Frame() {
+    if (input_buttons&2 && getstatf(STAT_HEALTH) > 0) {
+        if (pmove_onground) {
+            frames_since_onground = 0;
+        } else {
 
+            // next two frames after leaving ground
+            if (frames_since_onground <= 2) {
+                frames_since_onground = frames_since_onground + 1;
+
+            // third frame after leaving ground
+            } else if (frames_since_onground == 3) {
+                input_buttons &= ~2;
+                frames_since_onground = frames_since_onground + 1;
+            }
+        }
+    }
 }
 
 float(float save, float take, vector inflictororg) CSQC_Parse_Damage = {


### PR DESCRIPTION
…+jump binds, not just aux_jump (now redundant command, kept for compat)