### PR TITLE
making medicts start with 3 concussion grenades, when not limited by …

### DIFF
--- a/share/defs.h
+++ b/share/defs.h
@@ -996,7 +996,7 @@
 #define PC_MEDIC_GRENADE_TYPE_1		GR_TYPE_NORMAL
 /* #define PC_MEDIC_GRENADE_TYPE_2	 	// Configured in TeamFortress_SetEquipment() */
 #define PC_MEDIC_GRENADE_INIT_1		3
-#define PC_MEDIC_GRENADE_INIT_2		2
+#define PC_MEDIC_GRENADE_INIT_2		3
 #define PC_MEDIC_GRENADE_MAX_1		4
 #define PC_MEDIC_GRENADE_MAX_2		3
 #define PC_MEDIC_TF_ITEMS		0


### PR DESCRIPTION
stockfull is not used in huetf's 2v2 rules, which has oztf's loadout standards (3 cuss grens for medics). By making it defaults to 3 it will make no difference to servers using stockfull. Also won't affect if the server is set to `localinfo max_gren2_medic 2` since loadouts are set with a min: `min(PC_MEDIC_GRENADE_INIT_2,role.gren2_limits[5]);`