### PR TITLE
Fix missing jump sounds

### DIFF
--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -444,7 +444,9 @@ void ParseSBAR()
 }
 
 float(float entnum, float channel, string soundname, float vol, float attenuation, vector pos, float pitchmod) CSQC_Event_Sound = {
-    if !(entnum == player_localentnum)
+    // Filter out sounds we may have generated locally, unless we're just
+    // pretending to be that entity.
+    if (entnum != player_localentnum || is_spectator || is_observer)
         return 0;
 
     switch(soundname) {


### PR DESCRIPTION
Matching on player_localentnum is too broad since we assume the identity of other ents when spectating obseriving.  Filter these cases out.

It's possible we need isdemo() also; but at least the demos I tried worked.