### PR TITLE
Fix discard DOS

### DIFF
--- a/ssqc/actions.qc
+++ b/ssqc/actions.qc
@@ -75,6 +75,7 @@ void () TeamFortress_Discard = {
         default:
     }
     if ((newmis.ammo_rockets + newmis.ammo_cells + newmis.ammo_nails + newmis.ammo_shells) == 0) {
+        remove(newmis);
         return;
     }
 


### PR DESCRIPTION
Discard turns out to have a user triggerable DOS where we always create the entity, even if there is nothing to discard.  Spamming this you can fairly quickly crash a server by exhausting progs VM memory (32mb).