### PR TITLE
Improve grenade timers

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -536,6 +536,7 @@ float jump_counter;
 float grentimer_waiting;
 float last_pmove_onground;
 float last_vel_z;
+float last_death_time;
 
 vector FO_Hud_Icon_Size = [24, 24, 0];
 vector FO_Hud_Icon_Font_Size = [8, 8, 0];

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -112,6 +112,7 @@ void() CSQC_Parse_Event = {
             ApplyTransparencyToGrenTimer();
             break;
         case MSG_PLAYERDIE:
+            last_death_time = readfloat();
             StopGrenTimers();
             break;
         case MSG_CLIENT_MENU:
@@ -331,6 +332,9 @@ void PlayGrenTimer(float offset) {
 
 void ParseGrenPrimed(float grentype, float primetime) {
     local float timertype = cvar(FOCMD_GRENTIMER);
+
+    if (primetime < last_death_time)
+        return;
 
     if (timertype == 0) {
         AddSilentGrenTimer(grentype, 0);

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -1,5 +1,5 @@
 void ParseSBAR();
-void ParseGrenPrimed(float grentype, float timertype);
+void ParseGrenPrimed(float grentype, float primetime);
 void AddGrenTimer(float grentype, float offset);
 void AddSilentGrenTimer(float grentype, float offset);
 void StartGrenTimer(float slot, float grentype, float offset);
@@ -105,8 +105,8 @@ void() CSQC_Parse_Event = {
             break;
         case MSG_GRENPRIMED:
             float grentype = readfloat();
-            float timertype = cvar(FOCMD_GRENTIMER);
-            ParseGrenPrimed(grentype, timertype);
+            float primetime = readfloat();
+            ParseGrenPrimed(grentype, primetime);
             break;
         case MSG_GRENTHROWN:
             ApplyTransparencyToGrenTimer();
@@ -329,21 +329,29 @@ void PlayGrenTimer(float offset) {
     soundupdate(self, channel, sound, cvar(FOCMD_GRENTIMERVOLUME), 0, 0, 0, offset);
 }
 
-void ParseGrenPrimed(float grentype, float timertype) {
-    if(timertype == 0) {
+void ParseGrenPrimed(float grentype, float primetime) {
+    local float timertype = cvar(FOCMD_GRENTIMER);
+
+    if (timertype == 0) {
         AddSilentGrenTimer(grentype, 0);
-        return;
-    }
-
-    if(timertype == 1) {
+    } else if(timertype == 1) {
         AddGrenTimer(grentype, 0);
-        return;
-    }
+    } else if (timertype == 2) {
+        // We need to offset our sound by 2 RTT/2s:
+        //  The first is the already occurred delay to receive notification.
+        //  The second is the will-occur delay in sending throwgren back.
+        local float offset = getplayerkeyfloat(player_localnum,
+            INFOKEY_P_PING)/1000;
 
-    if(timertype == 2) {
-        local float offset = getplayerkeyfloat(player_localnum, INFOKEY_P_PING)/1000;
         AddGrenTimer(grentype, offset);
-        return;
+    } else if (timertype == 3) {
+        // As above, but uses precise accounting for the already occurred delay.
+        // Will eventually replace type==2.
+        local float offset_prime = time - primetime;
+        local float offset_throw = getplayerkeyfloat(player_localnum,
+            INFOKEY_P_PING)/1000 / 2;
+
+        AddGrenTimer(grentype, offset_prime + offset_throw);
     }
 }
 

--- a/ssqc/status.qc
+++ b/ssqc/status.qc
@@ -822,7 +822,8 @@ void UpdateClientPlayerDie(entity pl) = {
     msg_entity = pl;
     WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
     WriteByte(MSG_MULTICAST, MSG_PLAYERDIE);
-    multicast('0 0 0', MULTICAST_ONE_NOSPECS);
+    WriteFloat(MSG_MULTICAST, time);
+    multicast('0 0 0', MULTICAST_ONE_R_NOSPECS);
 }
 
 void UpdateClientIDString(entity pl) {

--- a/ssqc/status.qc
+++ b/ssqc/status.qc
@@ -803,6 +803,7 @@ void UpdateClientGrenadePrimed(entity pl, float grentype) = {
     WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
     WriteByte(MSG_MULTICAST, MSG_GRENPRIMED);
     WriteFloat(MSG_MULTICAST, grentype);
+    WriteFloat(MSG_MULTICAST, time);
     multicast('0 0 0', MULTICAST_ONE_R_NOSPECS);
 }
 


### PR DESCRIPTION
For CSQC enabled clients we synchronize the grenade timer with the server's notion of when the grenade was actually primed to eliminate ping dependency.

There's a bug in the current synchronization in that it offsets the predicted time by a full RTT, when the server starts the time when it receives the message, e.g. ~RTT/2.  This means that the timer has still been off by half-ping, better, but not perfect.

We correct this, but introduce a replacement implementation: the server additionally sends exactly what time it thinks the grenade was primed, so that we do not have to approximate it around ping.

We maintain the value of "fo_grentimer == 2" to mean, server assisted grenade timers, but default it to the new implementation.

We leave a temporary legacy fo_grentimer==3, which can be used if there are any issues with the new timers.  This will be deleted in a subsequent patch before merge to master.