### PR TITLE
Rate-limit feign and remove dead code

### DIFF
--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -531,6 +531,9 @@ void () DecodeLevelParms = {
         // print fake death message when feigning death [on]
         feign_msg = CF_GetSetting("fm", "feign_msg", "on");
 
+        // rate limit on feign
+        feign_rate_limit = CF_GetSetting("frl", "feign_rate_limit", "5");
+
         // turn off spy [off]
         spy_off = CF_GetSetting("spy", "spy", "off");
 	

--- a/ssqc/combat.qc
+++ b/ssqc/combat.qc
@@ -682,7 +682,7 @@ void (entity targ, entity inflictor, entity attacker, float damage,
     }
 
     if (self.feign_next_damage && !self.is_feigning){
-        FO_Spy_Feign(0);
+        FO_Spy_Feign(0, /* ignore rate-limit */ 1);
     }
 
     self = oldself;

--- a/ssqc/menu.qc
+++ b/ssqc/menu.qc
@@ -4,11 +4,9 @@
 
 void (entity pe_player, float pf_class) CF_Spy_ChangeSkin;
 void (entity pe_player, float pf_team_no) CF_Spy_ChangeColor;
-void (float issilent) CF_Spy_FeignDeath;
-void (float issilent) FO_Spy_Feign;
+void (float issilent, float force) FO_Spy_Feign;
 void () FO_Spy_FeignOnNextDamage;
 void () FO_Spy_Unfeign;
-void (float issilent) CF_Spy_FeignDeath;
 void () CF_Spy_Invisible;
 void () CF_Spy_DisguiseStop;
 
@@ -586,7 +584,7 @@ void (float inp) Menu_Spy_Input = {
     } else if (inp == 2 && !invis_only) {
         FO_Spy_DisguiseLast(self);
     } else if (inp == 3) {
-        CF_Spy_FeignDeath(1);
+        FO_Spy_Feign(1, 0);
         if (self.is_feigning) {
             Menu_Spy(self);
         }

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -401,6 +401,7 @@ float num_world_flames;
 .string undercover_name;
 .entity attacked_by;            // Used by spy feign death to produce a fake death message
 .float feignmsg;                // Stores the death message to be used when feigning
+.float next_feign_time;         // timestamp for when feign is next allowed
 
 float live_camera;
 .float camdist;
@@ -560,6 +561,7 @@ float fo_hwguy;
 float feign_air;
 float feign_pack;
 float feign_msg;
+float feign_rate_limit;
 float scoutdash;
 float sniperreload;
 float spawnfull;

--- a/ssqc/spy.qc
+++ b/ssqc/spy.qc
@@ -443,8 +443,15 @@ void (float issilent) FO_Spy_ToggleFeign = {
     }
 }
 
-void (float issilent) FO_Spy_Feign = {
+void (float issilent, float force) FO_Spy_Feign = {
     if (self.is_feigning) {
+        return;
+    }
+
+    if (!force && time <= self.next_feign_time) {
+        sprint(self, PRINT_HIGH, sprintf(
+            "%0.1f seconds until you have enough fake-blood to feign again!\n",
+            self.next_feign_time - time));
         return;
     }
 
@@ -459,6 +466,9 @@ void (float issilent) FO_Spy_Feign = {
     if (area_check == 3) {
         return;
     }
+
+    // Success.  We will feign.
+    self.next_feign_time = time + feign_rate_limit;
 
     // don't check for team color cheat for 5 seconds
     self.immune_to_check = time + 5;
@@ -617,152 +627,12 @@ void () FO_Spy_Unfeign = {
     }
 }
 
-void (float issilent) CF_Spy_FeignDeath = {
-    local string deathstring;
-    local float area_check;
-    local float i;
-    local entity te, spy;
-
-    if (self.is_feigning) {
-        // check area for obstructing entities
-        area_check = Spy_CheckArea(self);
-
-        // nothing on top => unfeign
-        if (!area_check) {
-
-            // set size of player model
-            setsize(self, VEC_HULL_MIN, VEC_HULL_MAX);
-
-            // set view height
-            self.view_ofs = '0 0 22';
-
-            // unset feign variables
-            self.is_feigning = 0;
-            self.feign_areachecked = 0;
-
-            // load saved weapon state and set current ammo
-            W_WeaponState_Load(self, 0);
-            W_SetCurrentAmmo(self);
-
-            // allow spy to move again
-            self.movetype = MOVETYPE_WALK;
-            self.tfstate = self.tfstate - (self.tfstate & TFSTATE_CANT_MOVE);
-            TeamFortress_SetSpeed(self);
-
-            // set revive animation
-            i = 1 + floor(random() * 5);
-            if (i == 1) {
-                spy_upb1();
-            } else if (i == 2) {
-                spy_upc1();
-            } else if (i == 3) {
-                spy_upd1();
-            } else {
-                spy_upe1();
-            }
-
-            // something is on top of spy
-        } else if (area_check == 1) {
-            sprint(self, PRINT_HIGH, "You cannot get up with something on top of you\n");
-        } else if (area_check == 2) {
-            sprint(self, PRINT_HIGH, "You cannot get up while someone is standing on you\n");
-        }
-    } else {
-
-        // don't allow feign if spy is in air and air feigning is disallowed
-        if (!feign_air && !(self.flags & FL_ONGROUND)) {
-            sprint(self, PRINT_HIGH, "You cannot feign while you are airborne\n");
-            return;
-        }
-
-        // check area for feigned spy on the ground
-        area_check = Spy_CheckArea(self);
-        if (area_check == 3) {
-            sprint(self, PRINT_HIGH, "You cannot feign on top of another spy\n");
-            return;
-        }
-
-        // don't check for team color cheat for 5 seconds
-        self.immune_to_check = time + 5;
-
-        // set movetype to toss
-        self.movetype = MOVETYPE_TOSS;
-
-        // this timer will make sure the spy falls
-        // to the ground when possible
-        spy = spawn();
-        spy.classname = "airtimer";
-        spy.owner = self;
-        spy.think = CF_Spy_AirThink;
-        spy.nextthink = time + 0.1;
-        // set spy feign variables
-        self.is_feigning = 1;
-        Attack_Finished(0.8);
-        self.invisible_finished = 0;
-        // set precached model index
-        self.modelindex = modelindex_player;
-        // set size of player model
-        setsize(self, '-16 -16 -24', '16 16 -16');
-        // set weapon state and remove weapon viewmodel
-        W_WeaponState_Save(self);
-        self.weaponmodel = "";
-        self.weaponframe = 0;
-        // set view height to ground
-        self.view_ofs = '0 0 4';
-        // do extra stuff if feign is not silent feign
-        if (issilent == 0) {
-            // make a death sound
-            DeathSound();
-            // drop an empty backpack (if this is not disabled in settings)
-            if (feign_pack)
-                Spy_DropBackpack();
-
-            // print feign message (if this is not disabled in settings)
-            if (feign_msg) {
-                deathstring = GetDeathMessage(self, self.attacked_by, self.feignmsg);
-                bprint(PRINT_MEDIUM, deathstring);
-                KillSound(self, self.attacked_by);
-            }
-            // set movement speed to 0 if currently in the air to disable manipulation of trajectory
-            if (!(self.flags & FL_ONGROUND))
-                self.maxspeed = 0;
-        }
-
-        // drop flag if spy is carrying it
-        te = find(world, classname, "item_tfgoal");
-        while (te) {
-            if (te.owner == self) {
-                if (!(te.goal_activation & TFGI_KEEP) || self.has_disconnected == 1)
-                    tfgoalitem_RemoveFromPlayer(te, self, 0);
-                if (CTF_Map == 1) {
-                    if (te.goal_no == 1)
-                        bprint(PRINT_HIGH, self.netname, Q" \slost\s the \sblue\s flag!\n");
-                    else if (te.goal_no == 2)
-                        bprint(PRINT_HIGH, self.netname, Q" \slost\s the \sred\s flag!\n");
-                }
-            }
-            te = find(te, classname, "item_tfgoal");
-        }
-        // die with axe equipped if carrying axe, medikit, knife or spanner
-        if (self.weapon <= WEAP_AXE) {
-            spy_die_ax1();
-            return;
-        }
-
-        // randomize death animation
-        i = 1 + floor((random() * 6));
-        if (i == 1)
-            spy_diea1();
-        else if (i == 2)
-            spy_dieb1();
-        else if (i == 3)
-            spy_diec1();
-        else if (i == 4)
-            spy_died1();
-        else
-            spy_diee1();
-    }
-};
+void (float issilent) FO_Spy_FeignCmd = {
+    if (self.is_feigning)
+        FO_Spy_Unfeign();
+    else
+        FO_Spy_Feign(issilent, 0);
+}
 
 void () CF_Spy_Invisible = {
     local entity e_timer;

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -1568,6 +1568,7 @@ void () TeamFortress_SetEquipment = {
     self.airblast_cooldown = 0;
     self.is_undercover = 0;
     self.is_feigning = 0;
+    self.next_feign_time = 0;
     self.is_unabletospy = 0;
     self.is_concussed = 0;
     self.disguise_skin = 0;

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -64,6 +64,7 @@ void () TeamFortress_EngineerBuildStop;
 void () TeamFortress_Scan;
 void () TeamFortress_Discard;
 void () TeamFortress_Discard_DropAmmo;
+void (float issilent) FO_Spy_FeignCmd;
 void (float issilent) FO_Spy_ToggleFeign;
 void () FO_Engineer_ToggleDispenser;
 void () FO_Engineer_ToggleSentry;
@@ -3147,11 +3148,11 @@ void () ImpulseCommands = {
         else
             Menu_Spy_Skin();
     } else if ((self.impulse == TF_SPY_DIE) && (self.playerclass == PC_SPY))
-        CF_Spy_FeignDeath(0);
+        FO_Spy_FeignCmd(0);
     else if ((self.impulse == TF_SPY_DIE_ON) && (self.playerclass == PC_SPY)) {
         FO_Spy_FeignOnNextDamage();
     } else if ((self.impulse == TF_SPY_SILENT_DIE) && (self.playerclass == PC_SPY))
-        CF_Spy_FeignDeath(1);
+        FO_Spy_FeignCmd(1);
     else if (self.impulse == TF_DISGUISE_RESET && self.playerclass == PC_SPY) {
         CF_Spy_ChangeSkin(self, 8);
         CF_Spy_ChangeColor(self, self.team_no);


### PR DESCRIPTION
Introduces a rate limit, set by localinfo feign_rate_limit [default=5s] which bounds how frequently you can manually feign.

Feigning in reaction to damage ignores this limit (e.g. you can manually feign, unfeign, take damage, and refeign), but it will still count towards your next manual feign.

Also, delete duplicate CF implementation of Feign.  Both implementations were previously being used.  If this breaks anything we'll have to figure out how they're different.