### PR TITLE
Further improve FTE performance

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -520,6 +520,12 @@ enum {
 #define FOCMD_JUMPVOLUME "fo_jumpvolume"
 #define FOCMD_ADMIN_MENU_UPDATE_TIME "fo_adminrefresh"
 #define FOCMD_FTE_HUD "fo_fte_hud"
+#define FOCMD_LEGACY_SBAR "fo_legacy_sbar"
+
+struct fo_settings {
+    float fte_hud;
+    float legacy_sbar;
+} settings;
 
 float team_no;
 float is_spectator;

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -13,6 +13,7 @@ void AddGrenTimer(float grentype, float offset);
 void ApplyTransparencyToGrenTimer();
 void StopGrenTimers();
 float IsValidToUseGrenades();
+void Sync_GameState();
 
 void GetSelf() = {
     self = findfloat(world, entnum, player_localentnum);
@@ -115,52 +116,14 @@ noref void() CSQC_WorldLoaded = {
 
 noref void(float width, float height, float menushown) CSQC_UpdateView = {
     ScreenSize = [width, height, menushown];
-    team_no = getstatf(STAT_TEAMNO);
-    is_observer = FALSE;
-    if (team_no == 0)
-        is_observer = TRUE;
-    player_class = getstatf(STAT_CLASS);
-    SBAR.ReadyStatus = getstatf(STAT_FLAGS);
-    oldhealth = getstatf(STAT_HEALTH);
-    is_spectator = stof(getplayerkeyvalue(player_localnum, "*spectator"));
-    if (is_spectator)
-        is_observer = FALSE;
     SBAR.Hint = "";
     thisorigin = (vector)getentity(player_localentnum, GE_ORIGIN);
-    //if(nextoriginupdate < time) {
-    //    speed = vlen([thisorigin.x, thisorigin.y] - [lastorigin.x, lastorigin.y]) * 10;
-    //    lastorigin = thisorigin;
-    //    nextoriginupdate = time + 0.1;
-    //}
-    vector vel = [getstatf(STAT_VELOCITY_X), getstatf(STAT_VELOCITY_Y), getstatf(STAT_VELOCITY_Z)];
-    speed = sqrt(vel.x * vel.x + vel.y * vel.y);
 
     clearscene();
     setproperty(VF_DRAWWORLD, 1); 		// we want to draw our world!
     setproperty(VF_DRAWCROSSHAIR, 1);		 // we want to draw our crosshair!
     if(cvar(FOCMD_FTE_HUD) != 1) {
         setproperty(VF_DRAWENGINESBAR, 1);		/* boolean. If set to 1, the sbar will be drawn, and viewsize will be honoured automatically. */
-    }
-    //setviewprop(VF_ORIGIN, '0 0 0');        //view position of the scene (after view_ofs effects).
-    //setviewprop(VF_ANGLES, '0 0 0');        //override the view angles. input will work as normal. other players will see your player as normal. your screen will just be pointing a different direction.
-    //setviewprop(VF_DRAWWORLD, 1);            //whether the world entity should be drawn. set to 0 if you want a completely empty scene.
-    //setviewprop(VF_MIN, '0 0 0');            //top-left coord (x,y) of the scene viewport in virtual pixels (or annoying physical pixels in dp).
-    //setviewprop(VF_SIZE, [width, height, 0]);    //virtual size (width,height) of the scene viewport in virtual pixels (or annoying physical pixels in dp).
-    //setviewprop(VF_AFOV, cvar("fov"));        //note: fov_x and fov_y control individual axis. afov is general
-    //setviewprop(VF_PERSPECTIVE, 1);        //1 means like quake and other 3d games. 0 means isometric.
-
-    local float health = getstatf(STAT_HEALTH);
-
-    if (health <= 0 || player_class != PC_SNIPER) {
-        zoomed_in = 0;
-    }
-
-    if (zoomed_in) {
-        setviewprop(VF_AFOV, cvar("fov")/3);
-        setsensitivityscaler(1/3);
-    } else {
-        setviewprop(VF_AFOV, cvar("fov"));
-        setsensitivityscaler(1);
     }
 
     addentities((intermission?0:MASK_VIEWMODEL)|MASK_ENGINE); 		// add entities with these rendermask field var's to our view
@@ -171,26 +134,6 @@ noref void(float width, float height, float menushown) CSQC_UpdateView = {
     Menu_Draw(width, height, menushown);
     Hud_Draw(width, height);
     sui_end();
-
-    local float paused = getstatf(STAT_PAUSED);
-
-    if (pmove_onground && health > 0 && !paused) {
-        // The pmove_vel_z < 180 check makes sure you're not sliding
-        if (input_buttons & BUTTON2 && pmove_vel_z < 180) {
-            localsound("player/plyrjmp8.wav", CHAN_BODY, cvar(FOCMD_JUMPVOLUME));
-        }
-
-        if (!last_pmove_onground) {
-            if (last_vel_z < -650) {
-                localsound("player/land2.wav", CHAN_AUTO, 1);
-            } else if (last_vel_z < -300) {
-                localsound("player/land.wav", CHAN_AUTO, 1);
-            }
-        }
-    }
-
-    last_vel_z = pmove_vel_z;
-    last_pmove_onground = pmove_onground;
 }
 
 noref float(string cmd) CSQC_ConsoleCommand = {
@@ -461,6 +404,8 @@ noref void CSQC_Input_Frame() {
     if (player_class == PC_SNIPER && keydowns & BUTTON3) {
         zoomed_in = !zoomed_in;
     }
+
+    Sync_GameState();
 }
 
 float(float save, float take, vector inflictororg) CSQC_Parse_Damage = {
@@ -497,4 +442,82 @@ void StopGrenTimers() {
         FO_Hud_Grentimers[i].expires = 0;
         FO_Hud_Grentimers[i].icon_index = 0;
     }
+}
+
+float last_servercommandframe;
+void _Sync_ServerCommandFrame() {
+    // Server command frames are monotonically unique, we can skip processing
+    // unless there is new state.
+    if (last_servercommandframe == servercommandframe)
+        return;
+    last_servercommandframe = servercommandframe;
+
+    team_no = getstatf(STAT_TEAMNO);
+    is_observer = FALSE;
+    if (team_no == 0)
+        is_observer = TRUE;
+    player_class = getstatf(STAT_CLASS);
+    SBAR.ReadyStatus = getstatf(STAT_FLAGS);
+    oldhealth = getstatf(STAT_HEALTH);
+    is_spectator = stof(getplayerkeyvalue(player_localnum, "*spectator"));
+    if (is_spectator)
+        is_observer = FALSE;
+
+    vector vel = [getstatf(STAT_VELOCITY_X), getstatf(STAT_VELOCITY_Y),
+                  getstatf(STAT_VELOCITY_Z)];
+    speed = sqrt(vel.x * vel.x + vel.y * vel.y);
+
+    local float health = getstatf(STAT_HEALTH);
+    if (health <= 0 || player_class != PC_SNIPER) {
+        zoomed_in = 0;
+    }
+
+    if (zoomed_in) {
+        setviewprop(VF_AFOV, cvar("fov")/3);
+        setsensitivityscaler(1/3);
+    } else {
+        setviewprop(VF_AFOV, cvar("fov"));
+        setsensitivityscaler(1);
+    }
+}
+
+float last_pmove_onground;
+float last_vel_z;
+float last_clientcommandframe;
+// REQUIRES: Must be called after _Sync_ServerCommandFrame.
+void _Sync_ClientCommandFrame() {
+    // Client command frames are regenerated beyond the server frame, so we
+    // cannot check that we have not seen this client command frame alone.
+    if (last_servercommandframe == servercommandframe &&
+        last_clientcommandframe == clientcommandframe)
+        return;
+    last_clientcommandframe = clientcommandframe;
+
+    local float paused = getstatf(STAT_PAUSED);
+    local float health = getstatf(STAT_HEALTH);
+
+    if (pmove_onground && health > 0 && !paused) {
+        // The pmove_vel_z < 180 check makes sure you're not sliding
+        if (input_buttons & BUTTON2 && pmove_vel_z < 180) {
+            localsound("player/plyrjmp8.wav", CHAN_BODY, cvar(FOCMD_JUMPVOLUME));
+        }
+
+        if (!last_pmove_onground) {
+            if (last_vel_z < -650) {
+                localsound("player/land2.wav", CHAN_AUTO, 1);
+            } else if (last_vel_z < -300) {
+                localsound("player/land.wav", CHAN_AUTO, 1);
+            }
+        }
+    }
+
+    last_vel_z = pmove_vel_z;
+    last_pmove_onground = pmove_onground;
+}
+
+// Called for each {client, server} command frame, ensures globals are
+// synchronized with server and predicted state.
+void Sync_GameState() {
+    _Sync_ServerCommandFrame();
+    _Sync_ClientCommandFrame();
 }

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -19,6 +19,21 @@ void GetSelf() = {
     self = findfloat(world, entnum, player_localentnum);
 }
 
+float last_cvar_update;
+void Update_Cached_CVars() {
+    // This is a little unfortunate, but there there doesn't appear to be an
+    // edge that can be captured (cvars do not count as commands), so we poll
+    // reasonably frequently (10hz).  This is a significant improvement versus
+    // reading them in the render path.
+    if (time - last_cvar_update < 0.1)
+        return;
+    last_cvar_update = time;
+
+    settings.fte_hud = cvar(FOCMD_FTE_HUD) == 1;
+    settings.legacy_sbar = cvar(FOCMD_LEGACY_SBAR) == 1;
+}
+
+
 noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     print("CSQC Started\n");
 
@@ -41,6 +56,7 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     registercvar(FOCMD_JUMPVOLUME, "1");
     registercvar(FOCMD_OLDSCOREBOARD, "0");
     registercvar(FOCMD_FTE_HUD, "0");
+    registercvar(FOCMD_LEGACY_SBAR, "0");
 
     registercommand("fo_menu_game");
     registercommand("fo_main_menu");
@@ -107,6 +123,8 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     current_vote = world;
     vote_list_filter = "";
     MouseDown = 0;
+
+    Update_Cached_CVars();
 };
 
 noref void() CSQC_WorldLoaded = {
@@ -122,9 +140,10 @@ noref void(float width, float height, float menushown) CSQC_UpdateView = {
     clearscene();
     setproperty(VF_DRAWWORLD, 1); 		// we want to draw our world!
     setproperty(VF_DRAWCROSSHAIR, 1);		 // we want to draw our crosshair!
-    if(cvar(FOCMD_FTE_HUD) != 1) {
-        setproperty(VF_DRAWENGINESBAR, 1);		/* boolean. If set to 1, the sbar will be drawn, and viewsize will be honoured automatically. */
-    }
+
+    // Draw original sbar, viewsize honoured automatically.
+    if (!settings.fte_hud || settings.legacy_sbar)
+        setproperty(VF_DRAWENGINESBAR, 1);
 
     addentities((intermission?0:MASK_VIEWMODEL)|MASK_ENGINE); 		// add entities with these rendermask field var's to our view
 
@@ -264,14 +283,14 @@ noref float(string cmd) CSQC_ConsoleCommand = {
                     localcmd(sprintf("bind %s +fo_showscores\n", key2));
                 }
             }
-            if(cvar(FOCMD_FTE_HUD)) {
+            if(settings.fte_hud) {
                 FO_Show_Scores(TRUE);
             }
             break;
         case "-showscores":
         case "-showteamscores":
             showingscores = FALSE;
-            if(cvar(FOCMD_FTE_HUD)) {
+            if(settings.fte_hud) {
                 FO_Show_Scores(FALSE);
             }
             break;
@@ -518,6 +537,7 @@ void _Sync_ClientCommandFrame() {
 // Called for each {client, server} command frame, ensures globals are
 // synchronized with server and predicted state.
 void Sync_GameState() {
+    Update_Cached_CVars();
     _Sync_ServerCommandFrame();
     _Sync_ClientCommandFrame();
 }

--- a/csqc/status.qc
+++ b/csqc/status.qc
@@ -148,7 +148,9 @@ void(string panelid, float display, string text) drawGrenTimerPanel = {
 };
 
 void(string panelid, float display, string text) drawFacePanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if (!settings.fte_hud)
+        return;
+
     local float playerclass = SBAR.PlayerClass; //we could add different faces per class?
 
     local string icon = FaceInvisibleInvulnerableIcon.icon;
@@ -185,7 +187,9 @@ void(string panelid, float display, string text) drawFacePanel = {
 };
 
 void(string panelid, float display, string text) drawArmourPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     local float playerclass = SBAR.PlayerClass;
 
     local string icon = fo_hud_editor?ArmourIcons[1].icon:"";
@@ -202,7 +206,9 @@ void(string panelid, float display, string text) drawArmourPanel = {
 };
 
 void(string panelid, float display, string text) drawAmmoPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     local string icon = fo_hud_editor?AmmoIcons[0].icon:"";
     
     local float items = getstatf(STAT_ITEMS);
@@ -215,7 +221,9 @@ void(string panelid, float display, string text) drawAmmoPanel = {
 };
 
 void(string panelid, float display, string text) drawInvIconPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     if(text && text != "") {
         drawIconPanel(panelid, display, "", text);
     } else if(fo_hud_editor) {
@@ -223,19 +231,27 @@ void(string panelid, float display, string text) drawInvIconPanel = {
     }
 };
 void(string panelid, float display, string text) drawInvShellsPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     drawIconPanel(panelid, display, text, AmmoIcons[0].icon);
 };
 void(string panelid, float display, string text) drawInvNailsPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     drawIconPanel(panelid, display, text, AmmoIcons[1].icon);
 };
 void(string panelid, float display, string text) drawInvRocketsPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     drawIconPanel(panelid, display, text, AmmoIcons[2].icon);
 };
 void(string panelid, float display, string text) drawInvCellsPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     drawIconPanel(panelid, display, text, AmmoIcons[3].icon);
 };
 
@@ -280,17 +296,23 @@ void(string panelid, float display, string text, float threshold) drawBigNumberP
 };
 
 void(string panelid, float display, string text) drawHealthTextPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     drawBigNumberPanel(panelid, display, text, 26);
 };
 
 void(string panelid, float display, string text) drawAmmoTextPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     drawBigNumberPanel(panelid, display, text, 11);
 };
 
 void(string panelid, float display, string text) drawClockPanel = {
-    if(!cvar(FOCMD_FTE_HUD)) return;
+    if(!settings.fte_hud)
+        return;
+
     drawBigNumberPanel(panelid, display, text, 0);
 };
 
@@ -1137,7 +1159,7 @@ var FO_Hud_Panel Hud_Panels[] = {
     {"gun6","Grenade Launcher",           '-4 -90',  '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_GRENADE_LAUNCHER);}, 0, 36},
     {"gun7","Rocket Launcher",            '-4 -70',  '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_ROCKET_LAUNCHER);}, 0, 36},
     {"gun8","Lighning Gun",               '-4 -50',  '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_LIGHTNING);}, 0, 36},
-    {"speed","Speed",                     '4 15',    '26 26',  1,1.4,0,0, drawTextPanel, {return cvar(FOCMD_FTE_HUD)?sprintf("%3.1f UPS", speed):"";}, 0, 4},
+    {"speed","Speed",                     '4 15',    '26 26',  1,1.4,0,0, drawTextPanel, {settings.fte_hud ? sprintf("%3.1f UPS", speed) : "";}, 0, 4},
 };
 
 //var FO_Hud_Panel Hud_ExtraPanels[] = {


### PR DESCRIPTION
I realized there were many more per-frame cvar queries hidden in the
status bar rendering code.  (These are more expensive than you might
think due to vm entry/exit, string wrapping, and look-up-by-string.)

Refactor these so that we instead use cached values in the render path,
which are periodically updated.

The performance improvement is quite nice when the FO hud is enabled.
There were many of these calls as they were per-panel.  Even at only
60fps (wayland forced vsync) I'm getting ~50% improvements in time spent
within CSQC frame rendering.

While we're in here, add fo_legacy_sbar for Novate.  Which allows use of
the original sbar (you'll still ne