### PR TITLE
Grenade ping correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ FortressOne Server
 New features
 ------
 
+* `localinfo project_grenades 0/1` [default: 0] Adjust the point at which
+  grenades are primed to correct for client latency.  Does not allow players to
+throw grenades any faster, or more frequently; only more consistently.
 * `setinfo precise_grenades on/off` to enable precise timing when throwing grenades.  This removes a random, up to, 100ms input delay.  (default on)
 * Server option to limit `sv_maxclients` to current number of players during quad gametime. `localinfo limit_quad_players 0/1`. Default: `1`.
 * `localinfo forcereload 0/1` Option to prevent forced reloads.

--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -436,14 +436,51 @@ typedef struct {
 } FO_Hud_Settings;
 FO_Hud_Settings HudSettings;
 
-typedef struct {
-    float grentype;
-    float expires;
-    float icon_index;
-    float alpha;
-} FO_Hud_Grentimer;
+enumflags {
+    FL_GT_SOUND,
+    FL_GT_THROWN,
+    FL_GT_ADJPING
+};
 
-FO_Hud_Grentimer FO_Hud_Grentimers[5];
+class CsGrenTimer;
+CsGrenTimer grentimers[NUM_GREN_TIMERS];
+
+class CsGrenTimer {
+    float primed_at_;
+    float expires_at_;
+    float flags_;
+    float channel_;
+    float grentype_;
+
+    nonvirtual float() active { return expires_at_ > time; };
+    nonvirtual float() expiry { return expires_at_; };
+    nonvirtual float() grentype { return grentype_; };
+    nonvirtual void() set_thrown { flags_ |= FL_GT_THROWN; };
+    nonvirtual float() is_thrown { return flags_ & FL_GT_THROWN; };
+
+    nonvirtual void(float primed_at, float expires_at,
+                    float grentype, float timer_flags) Set;
+    nonvirtual void() Stop;
+
+    static float next_index_;
+    static CsGrenTimer last_;
+
+    static void() Init {
+        for (float i = 0; i < grentimers.length; i++)
+            grentimers[i] = spawn(CsGrenTimer, channel_: CHAN_GREN_START + i);
+    };
+
+    static void() StopAll {
+        for (float i = 0; i < grentimers.length; i++)
+            grentimers[i].Stop();
+    };
+
+    static CsGrenTimer() GetNext {
+        return last_ = grentimers[next_index_++ % grentimers.length];
+    };
+
+    static CsGrenTimer() GetLast { return last_; };
+};
 
 // scoreboard stuff
 typedef struct {

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -1,10 +1,6 @@
 void ParseSBAR();
-void ParseGrenPrimed(float grentype, float primetime);
-void AddGrenTimer(float grentype, float offset);
-void AddSilentGrenTimer(float grentype, float offset);
-void StartGrenTimer(float slot, float grentype, float offset);
-void AddGrenTimer(float grentype, float offset);
-void PlayGrenTimer(float offset);
+void ParseGrenPrimed(float grentype, float primed_at, float explodes_at);
+float StartGrenTimer(float primed_at, float expires_at, float grentype, float play_sound);
 
 void() CSQC_Parse_Event = {
     float msgtype = readbyte();
@@ -104,12 +100,15 @@ void() CSQC_Parse_Event = {
             SBAR.Identify = readstring();
             break;
         case MSG_GRENPRIMED:
-            float grentype = readfloat();
-            float primetime = readfloat();
-            ParseGrenPrimed(grentype, primetime);
+            float grentype = readbyte();
+            float primed_at = readfloat();
+            float explodes_at = readfloat();
+            ParseGrenPrimed(grentype, primed_at, explodes_at);
             break;
         case MSG_GRENTHROWN:
-            ApplyTransparencyToGrenTimer();
+            CsGrenTimer last = CsGrenTimer::GetLast();
+            last.set_thrown();
+            //CsGrenTimer::GetLast().set_thrown();
             break;
         case MSG_PLAYERDIE:
             last_death_time = readfloat();
@@ -306,57 +305,56 @@ void() CSQC_Parse_Event = {
     }
 }
 
-void PlayGrenTimer(float offset) {
-    local float channel = CHAN_GREN1;
-    local float soundtime;
-    local float highest_soundtime = -1;
+void CsGrenTimer::Set(float primed_at, float expires_at, float _grentype,
+                      float timer_flags) {
+    grentype_ = _grentype;
+    primed_at_ = primed_at;
+    expires_at_ = expires_at;
+    flags_ = timer_flags;
 
-    for(float i = CHAN_GREN1; i <= CHAN_GREN5; i++) {
-        soundtime = getsoundtime(self, i);
-
-        if (soundtime < 0) {
-            channel = i;
-            break;
-        }
-
-        if (soundtime > highest_soundtime) {
-            highest_soundtime = soundtime;
-            channel = i;
-        }
+    if (this.flags_ & FL_GT_ADJPING) {
+        local float rtt =
+            getplayerkeyfloat(player_localnum, INFOKEY_P_PING) / 1000;
+        expires_at_ -= rtt/2;
     }
 
-    local string sound = cvar_string(FOCMD_GRENTIMERSOUND);
-    localsound(sound, channel, cvar(FOCMD_GRENTIMERVOLUME)); // required because soundupdate doesn't reset getsoundtime
-    soundupdate(self, channel, sound, cvar(FOCMD_GRENTIMERVOLUME), 0, 0, 0, offset);
-}
-
-void ParseGrenPrimed(float grentype, float primetime) {
-    local float timertype = cvar(FOCMD_GRENTIMER);
-
-    if (primetime < last_death_time)
+    if !(this.flags_ & FL_GT_SOUND)
         return;
 
-    if (timertype == 0) {
-        AddSilentGrenTimer(grentype, 0);
-    } else if(timertype == 1) {
-        AddGrenTimer(grentype, 0);
-    } else if (timertype == 2) {
-        // We need to offset our sound by 2 RTT/2s:
-        //  The first is the already occurred delay to receive notification.
-        //  The second is the will-occur delay in sending throwgren back.
-        local float offset = getplayerkeyfloat(player_localnum,
-            INFOKEY_P_PING)/1000;
+    local float adj = 3.8 - (expires_at_ - time);
+    string sound = cvar_string(FOCMD_GRENTIMERSOUND);
+    soundupdate(self, channel_, cvar_string(FOCMD_GRENTIMERSOUND),
+            cvar(FOCMD_GRENTIMERVOLUME), 0, 0, 0, adj);
+}
 
-        AddGrenTimer(grentype, offset);
-    } else if (timertype == 3) {
-        // As above, but uses precise accounting for the already occurred delay.
-        // Will eventually replace type==2.
-        local float offset_prime = time - primetime;
-        local float offset_throw = getplayerkeyfloat(player_localnum,
-            INFOKEY_P_PING)/1000 / 2;
+void CsGrenTimer::Stop() {
+    expires_at_ = -1;
+    if (flags_ & FL_GT_SOUND)
+        soundupdate(self, channel_, "", -1, 0, 0, 0, 0);  // -ve volume => stop.
+    flags_ = 0;
+}
 
-        AddGrenTimer(grentype, offset_prime + offset_throw);
+void StopGrenTimers() {
+    for (float i = 0; i < NUM_GREN_TIMERS; i++)
+        grentimers[i].Stop();
+}
+
+void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
+    if (grentype == GR_TYPE_FLARE || grentype == GR_TYPE_CALTROP)
+        return;
+
+    if (primed_at < last_death_time)
+        return;
+
+    local float timer_flags = 0;
+    switch (cvar(FOCMD_GRENTIMER)) {
+        case 0: break;
+        case 1: timer_flags = FL_GT_SOUND; break;
+        // 2 [and something sane for anything we don't recognize.]
+        default: timer_flags = FL_GT_SOUND | FL_GT_ADJPING; break;
     }
+    CsGrenTimer timer = CsGrenTimer::GetNext();
+    timer.Set(primed_at, explodes_at, grentype, timer_flags);
 }
 
 void ParseSBAR()

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -339,6 +339,8 @@ void StopGrenTimers() {
         grentimers[i].Stop();
 }
 
+DEFCVAR_FLOAT(fo_grentimer_debug, 0);
+
 void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
     if (grentype == GR_TYPE_FLARE || grentype == GR_TYPE_CALTROP)
         return;
@@ -355,6 +357,19 @@ void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
     }
     CsGrenTimer timer = CsGrenTimer::GetNext();
     timer.Set(primed_at, explodes_at, grentype, timer_flags);
+
+    if (CVARF(fo_grentimer_debug) == 1) {
+        float ping = getplayerkeyfloat(player_localnum, INFOKEY_P_PING) / 1000;
+
+        float expires_old = time + 3.8 - ping;
+        float expires_new = timer.expiry();
+        float expires_ideal = explodes_at - ping/2;
+
+        print(sprintf("primed_at=%0.2f explodes_at=%0.2f fuse=%0.2f\n",
+                    primed_at, explodes_at, explodes_at - primed_at));
+        print(sprintf("ideal=%0.2f new=%0.2f old=%0.2f\n",
+                expires_ideal, expires_new, expires_old));
+    }
 }
 
 void ParseSBAR()

--- a/csqc/hud_helpers.qc
+++ b/csqc/hud_helpers.qc
@@ -483,32 +483,3 @@ vector DrawOffsetString(string msg, vector size, vector fontSize, vector pos, ve
 
     return pos;
 }
-
-void AddGrenTimer(float grentype, float offset) {
-    if (grentype == GR_TYPE_FLARE || grentype == GR_TYPE_CALTROP)
-        return;
-
-    for(float i = 0; i < FO_Hud_Grentimers.length; i++) {
-        if(FO_Hud_Grentimers[i].grentype == 0) {
-            StartGrenTimer(i, grentype, offset);
-            PlayGrenTimer(offset);
-            break;
-        }
-    }
-}
-
-void AddSilentGrenTimer(float grentype, float offset) {
-    for(float i = 0; i < FO_Hud_Grentimers.length; i++) {
-        if(FO_Hud_Grentimers[i].grentype == 0) {
-            StartGrenTimer(i, grentype, offset);
-            break;
-        }
-    }
-}
-
-void StartGrenTimer(float slot, float grentype, float offset) {
-    FO_Hud_Grentimers[slot].grentype = grentype;
-    FO_Hud_Grentimers[slot].icon_index = grentype;
-    FO_Hud_Grentimers[slot].alpha = 1;
-    FO_Hud_Grentimers[slot].expires = time + 3.8 - offset;
-}

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -10,7 +10,6 @@ void Hud_WriteCfg(string path);
 void FO_LoadSettings();
 void FO_WriteSettings();
 void AddGrenTimer(float grentype, float offset);
-void ApplyTransparencyToGrenTimer();
 void StopGrenTimers();
 float IsValidToUseGrenades();
 void Sync_GameState();
@@ -27,6 +26,8 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
 //     for (float i = 0; i < HudIcons.length; i++) {
 //         precache_pic(HudIcons[i].icon);
 //     }
+
+    CsGrenTimer::Init();
 
     registercommand("fo_hud_editor");
     registercommand("fo_hud_reload");
@@ -446,29 +447,6 @@ float(float save, float take, vector inflictororg) CSQC_Parse_Damage = {
 
 void CSQC_Shutdown() = {
     FO_WriteSettings();
-}
-
-void ApplyTransparencyToGrenTimer() {
-    for(float i = 0; i < FO_Hud_Grentimers.length; i++) {
-        if (FO_Hud_Grentimers[i].grentype != 0 && FO_Hud_Grentimers[i].alpha != 0.3) {
-            FO_Hud_Grentimers[i].alpha = 0.3;
-            break;
-        }
-    }
-}
-
-void StopGrenTimers() {
-    soundupdate(self, CHAN_GREN1, "", 0, 0, 0, 0, 0);
-    soundupdate(self, CHAN_GREN2, "", 0, 0, 0, 0, 0);
-    soundupdate(self, CHAN_GREN3, "", 0, 0, 0, 0, 0);
-    soundupdate(self, CHAN_GREN4, "", 0, 0, 0, 0, 0);
-    soundupdate(self, CHAN_GREN5, "", 0, 0, 0, 0, 0);
-
-    for(float i = 0; i < FO_Hud_Grentimers.length; i++) {
-        FO_Hud_Grentimers[i].grentype = 0;
-        FO_Hud_Grentimers[i].expires = 0;
-        FO_Hud_Grentimers[i].icon_index = 0;
-    }
 }
 
 float last_servercommandframe;

--- a/csqc/status.qc
+++ b/csqc/status.qc
@@ -101,7 +101,6 @@ void(string panelid, float display, string text) drawGrenTimerPanel = {
 
     if (display) {
         FO_Hud_Panel* panel = getAnyHudPanelByNamePointer(panelid);
-        
         float Scale = panel.Scale;
         float TextScale = panel.TextScale;
         FO_Hud_Panel panel2;
@@ -111,35 +110,27 @@ void(string panelid, float display, string text) drawGrenTimerPanel = {
         panel2.Display = panel.Display;
         panel2.FillSize = panel.FillSize;
 
-        for(float i = 0; i < FO_Hud_Grentimers.length; i++) {
-            if(FO_Hud_Grentimers[i].grentype > 0) {
-                timeleft = floor(FO_Hud_Grentimers[i].expires - time) + 1;
-                if(timeleft < 1) {
-                    //Expire and fill the gap if there are any active grentimers afterwards
-                    FO_Hud_Grentimers[i].grentype = 0;
-                    for(float j = i + 1; j < FO_Hud_Grentimers.length; j++) {
-                        FO_Hud_Grentimers[j - 1].grentype = FO_Hud_Grentimers[j].grentype;
-                        FO_Hud_Grentimers[j - 1].expires = FO_Hud_Grentimers[j].expires;
-                        FO_Hud_Grentimers[j - 1].icon_index = FO_Hud_Grentimers[j].icon_index;
-                        FO_Hud_Grentimers[j - 1].alpha = FO_Hud_Grentimers[j].alpha;
-                    }
-                        FO_Hud_Grentimers[FO_Hud_Grentimers.length - 1].grentype = 0;
-                        FO_Hud_Grentimers[FO_Hud_Grentimers.length - 1].expires = 0;
-                        FO_Hud_Grentimers[FO_Hud_Grentimers.length - 1].icon_index = 0;
-                        FO_Hud_Grentimers[FO_Hud_Grentimers.length - 1].alpha = 0;
-                    continue;
-                }
+        for (float i = 0; i < grentimers.length; i++) {
+            local CsGrenTimer gt = grentimers[i];
 
-                if(i) {
-                    panel2.Scale = Scale * 0.8;
-                    panel2.TextScale = TextScale * 0.8;
-                }
+            if (!gt.active())
+                continue;
 
-                Hud_DrawPanelLMP(&panel2, ftos(timeleft), GrenadeIcons[FO_Hud_Grentimers[i].icon_index].icon, FO_Hud_Grentimers[i].alpha);
+            timeleft = floor(gt.expiry() - time) + 1;
+            if (timeleft < 1)
+                continue;
 
-                panel2.Position = panel2.Position + [0, panel2.FillSize.y * panel2.Scale];
-                timercount++;
+            if (timercount) {
+                panel2.Scale = Scale * 0.8;
+                panel2.TextScale = TextScale * 0.8;
             }
+
+            local float alpha = (gt.is_thrown()) ? 0.3 : 1.0;
+            Hud_DrawPanelLMP(&panel2, ftos(timeleft),
+                GrenadeIcons[gt.grentype()].icon, alpha);
+            panel2.Position = panel2.Position +
+                [0, panel2.FillSize.y * panel2.Scale];
+            timercount++;
         }
     }
     if(fo_hud_editor && (!display || !timercount)) {

--- a/share/defs.h
+++ b/share/defs.h
@@ -173,11 +173,9 @@
 #define CHAN_ITEM	3
 #define CHAN_BODY	4
 #define CHAN_NO_PHS_ADD	8
-#define CHAN_GREN1	9
-#define CHAN_GREN2	10
-#define CHAN_GREN3	11
-#define CHAN_GREN4	12
-#define CHAN_GREN5	13
+#define NUM_GREN_TIMERS 5
+#define CHAN_GREN_START 9
+#define CHAN_GREN_END (CHAN_GREN_START + NUM_GREN_TIMERS - 1)
 
 #define ATTN_NONE	0
 #define ATTN_NORM	1

--- a/ssqc/antilag.qc
+++ b/ssqc/antilag.qc
@@ -27,3 +27,20 @@ void AL_ProjectProjectile (entity projectile) {
 
       setorigin(projectile, projected_origin);
 }
+
+float AL_GrenadeOffset() {
+    if (!CF_GetSetting("pg", "project_grenades", "off"))
+        return 0;
+
+    local float offset = infokeyf(self, INFOKEY_P_PING) / 1000;
+    local float smallest_grenade_think = 0.5;
+
+    offset /= 2;
+    // Make sure we'll always order before first think.
+    offset = min(offset, smallest_grenade_think - 0.1);
+
+    // Don't allow prime to move before throw (or to the same frame).
+    offset = min(offset, time - (self.last_throw + 0.013));
+
+    return offset;
+}

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -1489,7 +1489,7 @@ void () spawn_guard_think = {
                 if(!te.has_disconnected && infokey(te, "dap") == "1") {
                     oldself = self;
                     self = te;
-                    TeamFortress_PrimeGrenade(1);
+                    TeamFortress_PrimeGrenade(1, FALSE);
                     self = oldself;
                 }
                 te = find (te, classname, "player");

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -763,6 +763,7 @@ float FO_FlashDimension;
 
 // precise grenades
 .entity grenade_timer;
+.float last_throw;
 
 // allow for default goal state
 .float default_group_no;
@@ -785,9 +786,10 @@ string goal_class_names[7] = {
 
 // people complain about settings, let's track them
 
-string settings_to_track_list[2] = {
+string settings_to_track_list[3] = {
     "sv_antilag",
-    "project_weapons"
+    "project_weapons",
+    "project_grenades",
 };
 
 typedef struct setting_t {

--- a/ssqc/status.qc
+++ b/ssqc/status.qc
@@ -796,14 +796,15 @@ string GetSBClassInfo(entity pl, float csqcactive)
     return st1;
 }
 
-void UpdateClientGrenadePrimed(entity pl, float grentype) = {
+void UpdateClientGrenadePrimed(entity pl, float grentype, float explodes_at) = {
     if(!infokeyf(pl, INFOKEY_P_CSQCACTIVE))
         return;
     msg_entity = pl;
     WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
     WriteByte(MSG_MULTICAST, MSG_GRENPRIMED);
-    WriteFloat(MSG_MULTICAST, grentype);
+    WriteByte(MSG_MULTICAST, grentype);
     WriteFloat(MSG_MULTICAST, time);
+    WriteFloat(MSG_MULTICAST, explodes_at);
     multicast('0 0 0', MULTICAST_ONE_R_NOSPECS);
 }
 

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -790,6 +790,7 @@ void () GrenadeTimer = {
 void (entity timer) FO_SpawnThrownGrenade = {
     local entity user = timer.owner;
     user.tfstate &= ~(TFSTATE_GRENPRIMED | TFSTATE_GRENTHROWING);
+    user.last_throw = time;
 
     if (grentimers && infokeyf(user, INFOKEY_P_CSQCACTIVE)) {
         UpdateClientGrenadeThrown(user);
@@ -923,7 +924,7 @@ void (float inp) TeamFortress_PrimeThrowGrenade = {
         (self.tfstate & TFSTATE_GRENTHROWING))
         TeamFortress_ThrowGrenade();
     else {
-        TeamFortress_PrimeGrenade(inp);
+        TeamFortress_PrimeGrenade(inp, TRUE);
 
     if ( ((inp == 1 && self.tp_grenade_switch != 1) || (inp == 2 && self.tp_grenade_switch == 1))
                 && self.tp_grenades_1 == GR_TYPE_CALTROP)
@@ -935,7 +936,9 @@ void () TeamFortress_GrenadePrimedThink;
 void () FO_PreciseGrenadeThink;
 float () FO_UsePreciseGrenades;
 
-void (float inp) TeamFortress_PrimeGrenade = {
+// is_player defines whether this originated from the player or server.  Player
+// generated primes are corrected for latency when project_grenades is on.
+void (float inp, float is_player) TeamFortress_PrimeGrenade = {
     local float gtype;
     local string gs;
     local string ptime;
@@ -1098,12 +1101,14 @@ void (float inp) TeamFortress_PrimeGrenade = {
         tGrenade.impulse = TF_GRENADE_1;
     else if (inp == 2)
         tGrenade.impulse = TF_GRENADE_2;
-    tGrenade.nextthink = time + 0.8;
 
+    local float lag_adjust = is_player ? AL_GrenadeOffset() : 0;
+
+    tGrenade.nextthink = time + 0.8 - lag_adjust;
     if (gtype == GR_TYPE_CALTROP)
-        tGrenade.heat = time + 0.5 + 0.5;
+        tGrenade.heat = time + 0.5 + 0.5 - lag_adjust;
     else {
-        tGrenade.heat = time + 3 + 0.8;
+        tGrenade.heat = time + 3 + 0.8 - lag_adjust;
 
         RemoveGrenadeTimers();
 
@@ -1111,7 +1116,7 @@ void (float inp) TeamFortress_PrimeGrenade = {
         local float notimers = stof(infokey(self, "nt"));
         if (grentimers && notimers != 1) {
             timer = spawn();
-            timer.nextthink = time + 0.8;
+            timer.nextthink = time + 0.8 - lag_adjust;
             timer.think = GrenadeTimer;
             timer.heat = 4;
             timer.owner = self;
@@ -1121,7 +1126,7 @@ void (float inp) TeamFortress_PrimeGrenade = {
             }
         }
         if (grentimers && csqcactive) {
-            UpdateClientGrenadePrimed(self, gtype);
+            UpdateClientGrenadePrimed(self, gtype, tGrenade.heat);
         }
     }
 

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -30,7 +30,7 @@ void () TeamFortress_ShowTF;
 void () TeamFortress_AssaultWeapon;
 void () TeamFortress_IncendiaryCannon;
 void () TeamFortress_FlameThrower;
-void (float inp) TeamFortress_PrimeGrenade;
+void (float inp, float is_player) TeamFortress_PrimeGrenade;
 void () TeamFortress_ThrowGrenade;
 void (float inp) TeamFortress_PrimeThrowGrenade;
 void () TeamFortress_GrenadeSwitch;
@@ -3020,9 +3020,9 @@ void () ImpulseCommands = {
 
     if (!self.is_feigning) {
         if (self.impulse == TF_GRENADE_1)
-            TeamFortress_PrimeGrenade(1);
+            TeamFortress_PrimeGrenade(1, TRUE);
         else if (self.impulse == TF_GRENADE_2)
-            TeamFortress_PrimeGrenade(2);
+            TeamFortress_PrimeGrenade(2, TRUE);
         else if (self.impulse == TF_GRENADE_T)
             TeamFortress_ThrowGrenade();
         else if (self.impulse == TF_GRENADE_PT_1)
@@ -3510,7 +3510,7 @@ void () ButtonFrame = {
     // +grenade1 keydown frame
     if (keydowns & BUTTON5) {
         if (hold_grens) {
-            TeamFortress_PrimeGrenade(1);
+            TeamFortress_PrimeGrenade(1, TRUE);
         } else {
             TeamFortress_PrimeThrowGrenade(1);
         }
@@ -3526,7 +3526,7 @@ void () ButtonFrame = {
     // +grenade2 keydown frame
     if (keydowns & BUTTON6) {
         if (hold_grens) {
-            TeamFortress_PrimeGrenade(2);
+            TeamFortress_PrimeGrenade(2, TRUE);
         } else {
             TeamFortress_PrimeThrowGrenade(2);
         }


### PR DESCRIPTION
Due to their prime-wait-throw nature, grenades have all sorts of
inconsistencies introduced by delay between client and server around
each event.  E.g. The player's idea of when they are priming and throwing
does not match up with the server's.

Two players that see each other at the same time, and prime at the same
time, will actually not be able to throw at the same time as the
player with the lower ping is able to get the server to register their
prime first.

This is particularly material since grenades don't allow you to throw
for the first 800ms, so even 50-100ms ping differences are a large
relative advantage.

This introduces ping correction, so that the point at which we consider
the client to have primed is corrected for their latency when enabled.
We ensure that this does not let players prime any faster, or more
frequently, than they would have been able to before, only more
consistently.

One very nice property is that unlike projectile projection, which
causes visible projectiles to skip, there are no strange artifacts for
other clients as the adjustment occurs before it's possible to throw the
grenade.

Also rewrite the grenade timer rendering client code to be more compact
and to handle the fact that the expiry offset has been adjusted to
correct for latency.

Clients that do not support CSQC can simply playsound at the point which
they prime; this will now be correctly aligned (as the point they primed
is properly reflected to the server).

Controlled by:
  localinfo precise_grenades on/off

While we'd normally default a server setting on, this is a big enough
change that we'll give it a pug or two of testing before pushing it as a
default to soak.  [For this reason we also temporarily allow mid-round
changing of the tunable.]