### PR TITLE
The hunt continues.

### DIFF
--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -307,15 +307,13 @@ void() CSQC_Parse_Event = {
 
 DEFCVAR_FLOAT(fo_grentimer_debug, 0);
 
-void play_retry(string sound, float channel, float volume, float adj) {
-    for (float i = 0; i < 3; i++) {
-        float update = soundupdate(world, channel, sound, volume, 0, 0, 0, adj);
-        if (CVARF(fo_grentimer_debug) & 1)
-               print(sprintf("%d soundupdate(%d) = %0.2f!\n", i, channel, update));
-        if (update == TRUE) {
-            return;
-        }
+string cached_timer;
+string GetGrenTimerSound() {
+    string wav = cvar_string(FOCMD_GRENTIMERSOUND);
+    if (cached_timer != wav) {
+        cached_timer = wav;
     }
+    return wav;
 }
 
 void OldPlayGren(float offset) {
@@ -324,7 +322,7 @@ void OldPlayGren(float offset) {
     local float highest_soundtime = -1;
 
     for(float i = CHAN_GREN_START; i <= CHAN_GREN_END; i++) {
-        soundtime = getsoundtime(self, i);
+        soundtime = getsoundtime(world, i);
 
         if (soundtime < 0) {
             channel = i;
@@ -337,9 +335,9 @@ void OldPlayGren(float offset) {
         }
     }
 
-    local string sound = cvar_string(FOCMD_GRENTIMERSOUND);
-    localsound(sound, channel, cvar(FOCMD_GRENTIMERVOLUME)); // required because soundupdate doesn't reset getsoundtime
-    soundupdate(world, channel, sound, cvar(FOCMD_GRENTIMERVOLUME), 0, 0, 0, offset);
+    local string wav = GetGrenTimerSound();
+    localsound(wav, channel, cvar(FOCMD_GRENTIMERVOLUME)); // required because soundupdate doesn't reset getsoundtime
+    soundupdate(world, channel, wav, cvar(FOCMD_GRENTIMERVOLUME), 0, 0, 0, offset);
 }
 
 void CsGrenTimer::Set(float primed_at, float expires_at, float _grentype,
@@ -359,13 +357,14 @@ void CsGrenTimer::Set(float primed_at, float expires_at, float _grentype,
         return;
 
     local float adj = 3.8 - (expires_at_ - time);
-    string sound = cvar_string(FOCMD_GRENTIMERSOUND);
+    string wav = GetGrenTimerSound();
     float volume = cvar(FOCMD_GRENTIMERVOLUME);
 
-    if (CVARF(fo_grentimer_debug) & 4) {
-        localsound(sound, channel_, 0);
-        play_retry(sound, channel_, volume, adj);
+    if (CVARF(fo_grentimer_debug) & 2) {
+        localsound(wav, channel_, volume);
+        soundupdate(world, channel_, wav, volume, 0, 0, 0, adj);
     } else {
+        // Default to old until new gets more testing.
         OldPlayGren(adj);
     }
 }

--- a/share/defs.h
+++ b/share/defs.h
@@ -172,10 +172,13 @@
 #define CHAN_VOICE	2
 #define CHAN_ITEM	3
 #define CHAN_BODY	4
-#define CHAN_GREN_START 5
-#define CHAN_GREN_END 7
 #define CHAN_NO_PHS_ADD	8
+
+// We can overlap these with regular channels since they play on the world ent.
 #define NUM_GREN_TIMERS 5 // We overlap channels when >3 active.
+#define CHAN_GREN_START 5
+#define CHAN_GREN_END 9
+// #define CHAN_GREN_END (CHAN_GREN_START + NUM_GREN_TIMERS - 1)
 
 #define ATTN_NONE	0
 #define ATTN_NORM	1


### PR DESCRIPTION
So a major part of the issue seems to be that the reference "self" was changing due to migration of timers into a class.  However, it turns out we were getting fortunate before and that self was actually the world entity and not the player.  This turns out to be the entire reason that soundupdate even worked with localsound, as the latter implies a default entity of zero.  This explains why we got double sounds even with the identical calls under the new code (as implicit entities from the grentimer entities were substituted.

This seems to work, I get very occasional misses, but I suspect those were the ones you were also seeing before.

I'm not sure about the PHS stuff, I've gone through the FTE code and it doesn't look like it's strongly interpreted for Q1 despite the docs and other mod's usage.  I've restored the extra channels for now.

I've left the old sound code as the default while I test the new one in a few pugs before flipping them.

Also made sure the timer sound was cached to avoid potential hitching (and anything to generally increase reliability).