### PR TITLE
More tweaks for grentimer reliability

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -471,7 +471,7 @@ class CsGrenTimer {
 
     static void() Init {
         float num_gren_sound = CHAN_GREN_END - CHAN_GREN_START + 1;
-        for (float i = 0; i < NUM_GREN_TIMERS; i++)
+        for (float i = 0; i < grentimers.length; i++)
             grentimers[i] = spawn(CsGrenTimer,
                     entnum: 10000 + i,
                     channel_: CHAN_GREN_START + (i % num_gren_sound));
@@ -483,7 +483,9 @@ class CsGrenTimer {
     };
 
     static CsGrenTimer() GetNext {
-        return last_ = grentimers[next_index_++ % grentimers.length];
+        next_index_ = (next_index_ + 1) % grentimers.length;
+        last_ = grentimers[next_index_];
+        return last_;
     };
 
     static CsGrenTimer() GetLast { return last_; };

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -108,7 +108,6 @@ void() CSQC_Parse_Event = {
         case MSG_GRENTHROWN:
             CsGrenTimer last = CsGrenTimer::GetLast();
             last.set_thrown();
-            //CsGrenTimer::GetLast().set_thrown();
             break;
         case MSG_PLAYERDIE:
             last_death_time = readfloat();
@@ -311,6 +310,7 @@ string cached_timer;
 string GetGrenTimerSound() {
     string wav = cvar_string(FOCMD_GRENTIMERSOUND);
     if (cached_timer != wav) {
+        precache_sound(wav);
         cached_timer = wav;
     }
     return wav;
@@ -359,18 +359,16 @@ void CsGrenTimer::Set(float primed_at, float expires_at, float _grentype,
     string wav = GetGrenTimerSound();
     float volume = cvar(FOCMD_GRENTIMERVOLUME);
 
-    // Can't localsound since that goes to world.  There's also a bug where
-    // starting sound with soundupdate returns false, even though it started,
-    // so "retry" for that as well as resiliency for now.
-    soundupdate(this, CHAN_WEAPON, wav, volume, 0, 0, 0, sound_offset());
-    soundupdate(this, CHAN_WEAPON, wav, volume, 0, 0, 0, sound_offset());
+    // Note there's a bug where soundupdate returns false for a new sample, even
+    // though it's started.
+    soundupdate(this, CHAN_VOICE, wav, volume, 0, 0, 0, sound_offset());
 }
 
 
 void CsGrenTimer::Stop() {
     expires_at_ = -1;
     if (flags_ & FL_GT_SOUND)
-        soundupdate(this, CHAN_WEAPON, "", -1, 0, 0, 0, 0);  // -volume => stop.
+        soundupdate(this, CHAN_VOICE, "", -1, 0, 0, 0, 0);  // -volume => stop.
     flags_ = 0;
 }
 
@@ -401,10 +399,10 @@ void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
     }
 
     float debug_print_state = CVARF(fo_grentimer_debug) & 1;
-    float debug_use_old_sound = CVARF(fo_grentimer_debug) & 2;
+    float debug_use_new_sound = CVARF(fo_grentimer_debug) & 2;
 
     float play_old_sound = FALSE;
-    if (debug_use_old_sound) {
+    if (!debug_use_new_sound) {
         play_old_sound = timer_flags & FL_GT_SOUND;
         timer_flags &= ~FL_GT_SOUND;
     }

--- a/share/defs.h
+++ b/share/defs.h
@@ -176,8 +176,8 @@
 
 // We can overlap these with regular channels since they play on the world ent.
 #define NUM_GREN_TIMERS 5 // We overlap channels when >3 active.
-#define CHAN_GREN_START 5
-#define CHAN_GREN_END 9
+#define CHAN_GREN_START 9
+#define CHAN_GREN_END 13
 // #define CHAN_GREN_END (CHAN_GREN_START + NUM_GREN_TIMERS - 1)
 
 #define ATTN_NONE	0


### PR DESCRIPTION
Flip default to old timers so we don't pick up grentimer_debug into clients for testing.

In effort to mirror original magically working state (which is the default), restore original channels.

Fix caching which got dropped in merge.

Small cleanups.