### PR TITLE
Ensure negative offsets can't be emitted.

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -449,7 +449,6 @@ class CsGrenTimer {
     float primed_at_;
     float expires_at_;
     float flags_;
-    float channel_;
     float grentype_;
 
     nonvirtual float() active { return expires_at_ > time; };
@@ -457,9 +456,9 @@ class CsGrenTimer {
     nonvirtual float() grentype { return grentype_; };
     nonvirtual void() set_thrown { flags_ |= FL_GT_THROWN; };
     nonvirtual float() is_thrown { return flags_ & FL_GT_THROWN; };
-    nonvirtual float() channel { return channel_; };
     nonvirtual float() sound_offset {
-        return 3.8 - (expires_at_ - time);
+        float offset = max(3.8 - (expires_at_ - time), 0);
+        return offset;
     };
 
     nonvirtual void(float primed_at, float expires_at,
@@ -470,11 +469,8 @@ class CsGrenTimer {
     static CsGrenTimer last_;
 
     static void() Init {
-        float num_gren_sound = CHAN_GREN_END - CHAN_GREN_START + 1;
         for (float i = 0; i < grentimers.length; i++)
-            grentimers[i] = spawn(CsGrenTimer,
-                    entnum: 10000 + i,
-                    channel_: CHAN_GREN_START + (i % num_gren_sound));
+            grentimers[i] = spawn(CsGrenTimer);
     };
 
     static void() StopAll {

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -420,7 +420,7 @@ void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
         float expires_new = timer.expiry();
         float expires_ideal = explodes_at - ping/2;
 
-        print(sprintf("primed_at=%0.2f explodes_at=%0.2f fuse=%0.2f new_s=%d\n",
+        print(sprintf("primed_at=%0.2f explodes_at=%0.2f fuse=%0.2f new=%d\n",
                     primed_at, explodes_at, explodes_at - primed_at,
                     debug_use_new_sound));
         print(sprintf("ideal=%0.2f new=%0.2f old=%0.2f\n",


### PR DESCRIPTION
Small inconsistencies between client time and server time can result in minute negative offsets that can stop the sound from playing.