### PR TITLE
Fix not-exploding napalm grenades

### DIFF
--- a/ssqc/pyro.qc
+++ b/ssqc/pyro.qc
@@ -134,7 +134,23 @@ void () NapalmGrenadeTouch = {
         self.avelocity = '0 0 0';
 };
 
-void () NapalmGrenadeNetThink = {
+void () NapalmGrenadeExplode2;
+
+// Explode1 is the initial "flare" before we start emitting dmg.
+// Explode2 handles the subsequent explosions.
+void () NapalmGrenadeExplode1 = {
+    local entity head;
+
+    FO_Sound(self, CHAN_AUTO, "weapons/flmgrexp.wav", 1, ATTN_NORM);
+    traceline(self.origin, self.origin, 1, self);
+    if (trace_inwater != 1)
+        self.effects = self.effects | EF_DIMLIGHT;
+    self.think = NapalmGrenadeExplode2;
+    self.nextthink = time + 0.1;
+    self.heat = 0;
+};
+
+void () NapalmGrenadeExplode2 = {
     local entity head;
     local entity te;
 
@@ -153,81 +169,44 @@ void () NapalmGrenadeNetThink = {
             break;
     }
 
-    if (self.heat == 0) {
-        self.owner.no_active_napalm_grens =
-            self.owner.no_active_napalm_grens + 1;
-        if (self.owner.no_active_napalm_grens > 2) {
-            te = find(world, classname, "grentimer");
-            while (te) {
-                if ((te.owner == self.owner) &&
-                    (te.no_active_napalm_grens == 1)) {
-                    te.weapon = DMSG_FLAME;
-                    te.think = RemoveGrenade;
-                    te.nextthink = time + 0.1;
-                }
-                te = find(te, classname, "grentimer");
-            }
-        }
-        self.no_active_napalm_grens = self.owner.no_active_napalm_grens;
-    }
     self.nextthink = time + 1;
-    self.origin = self.enemy.origin;
     makevectors(self.v_angle);
     traceline(self.origin, self.origin, 1, self);
-    if (trace_inwater == 1) {
+
+    local float ignited = self.effects & EF_DIMLIGHT;
+    if (trace_inwater == 1 && ignited) {
+        self.effects &= ~EF_DIMLIGHT;  // Extinguish.
         FO_Sound(self, CHAN_VOICE, "misc/vapeur2.wav", 1, ATTN_NORM);
-        RemoveGrenade();
-        return;
-    }
-    head = findradius(self.origin, 180);
-    while (head) {
-        if (head.takedamage) {
-            deathmsg = DMSG_FLAME;
-            
-            TF_T_Damage(head, self, self.owner, explodeDam, TF_TD_NOTTEAM,
-                        TF_TD_FIRE);
-            other = head;
-            Napalm_touch();
-            if (other.classname == "player") {
-                stuffcmd(other, "bf\nbf\n");
+    } else if (ignited) {
+        head = findradius(self.origin, 180);
+        while (head) {
+            if (head.takedamage) {
+                deathmsg = DMSG_FLAME;
+
+                TF_T_Damage(head, self, self.owner, explodeDam, TF_TD_NOTTEAM,
+                            TF_TD_FIRE);
+                other = head;
+                Napalm_touch();
+                if (other.classname == "player") {
+                    stuffcmd(other, "bf\nbf\n");
+                }
             }
+            head = head.chain;
         }
-        head = head.chain;
+        WriteByte(MSG_MULTICAST, SVC_TEMPENTITY);
+        WriteByte(MSG_MULTICAST, TE_EXPLOSION);
+        WriteCoord(MSG_MULTICAST, self.origin_x);
+        WriteCoord(MSG_MULTICAST, self.origin_y);
+        WriteCoord(MSG_MULTICAST, self.origin_z);
+        multicast(self.origin, MULTICAST_PHS);
     }
-    WriteByte(MSG_MULTICAST, SVC_TEMPENTITY);
-    WriteByte(MSG_MULTICAST, TE_EXPLOSION);
-    WriteCoord(MSG_MULTICAST, self.origin_x);
-    WriteCoord(MSG_MULTICAST, self.origin_y);
-    WriteCoord(MSG_MULTICAST, self.origin_z);
-    multicast(self.origin, MULTICAST_PHS);
 
     self.heat = self.heat + 1;
-    
+
     if (self.heat >= maxExplosions)
-        RemoveGrenade();
-};
-
-void () NapalmGrenadeExplode = {
-    local entity head;
-
-    FO_Sound(self, CHAN_AUTO, "weapons/flmgrexp.wav", 1, ATTN_NORM);
-    traceline(self.origin, self.origin, 1, self);
-    if (trace_inwater == 1) {
         dremove(self);
-        return;
-    }
-    self.effects = self.effects | EF_DIMLIGHT;
-    head = spawn();
-    head.think = NapalmGrenadeNetThink;
-    head.classname = "grentimer";
-    head.grenadename = "napalmfire";
-    head.nextthink = time + 0.1;
-    head.heat = 0;
-    head.origin = self.origin;
-    head.owner = self.owner;
-    head.team_no = self.owner.team_no;
-    head.enemy = self;
 };
+
 
 void (vector org, entity shooter) NapalmGrenadeLaunch = {
     local float xdir;

--- a/ssqc/quadmode.qc
+++ b/ssqc/quadmode.qc
@@ -518,12 +518,6 @@ void () StartQuadRound =
 		gren.nextthink = (time + 0.1);
 		gren = find(gren, classname, "grenade");
 	}
-	gren = find(world, classname, "grentimer");
-	while (gren) {
-		gren.think = SUB_Remove;
-		gren.nextthink = (time + 0.1);
-		gren = find(gren, classname, "grentimer");
-	}
 	te = find(world, classname, "detpack");
 	while (te){
 		if (te.weaponmode == 1) {

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -241,8 +241,6 @@ float coop;
 .float last_saveme_sound;
 
 .float no_active_nail_grens;
-.float no_active_napalm_grens;
-.float no_active_gas_grens;
 
 /*======================================================================*/
 /* TEAMFORTRESS GOALS							*/

--- a/ssqc/spy.qc
+++ b/ssqc/spy.qc
@@ -1,7 +1,6 @@
 void (entity Item, entity AP, float method) tfgoalitem_RemoveFromPlayer;
 void (entity spy) TeamFortress_SpyCalcName;
 void () CF_Spy_UndercoverThink;
-void () GasGrenadeMakeGas;
 void () T_TranqDartTouch;
 void () Spy_DropBackpack;
 void (entity targ, entity attacker) KillSound;
@@ -1089,22 +1088,20 @@ void () GasGrenadeTouch = {
         self.avelocity = '0 0 0';
 };
 
-void () GasGrenadeExplode = {
-    local entity te;
+void () GasGrenadeExplode2;
+
+// GasGrenadeExplode1 handles the initial "pre-explosion".
+// GasGrenadeExplode2 handles aoe emission.
+void () GasGrenadeExplode1 = {
     local float pos;
 
     pos = pointcontents(self.origin);
     if (pos == -1) {
-        te = spawn();
-        te.think = GasGrenadeMakeGas;
-        te.nextthink = time + 0.1;
-        te.classname = "gastimer";
-        te.heat = 0;
-        te.origin = self.origin;
-        te.owner = self.owner;
-        te.team_no = self.owner.team_no;
-        te.weapon = 0;
-        te.enemy = self;
+        self.think = GasGrenadeExplode2;
+        self.nextthink = time + 0.1;
+        self.heat = 0;
+        self.dimension_seen = DMN_INVISIBLE;
+        self.movetype = MOVETYPE_NONE;
     } else {
         pos = 0;
         while (pos < 10) {
@@ -1123,31 +1120,14 @@ void () GasGrenadeExplode = {
             setsize(newmis, '-8 -8 -8', '8 8 8');
             pos = pos + 1;
         }
+        dremove(self);
     }
-    dremove(self);
 };
 
-void () GasGrenadeMakeGas = {
+void () GasGrenadeExplode2 = {
     local entity te;
     local entity timer;
 
-    if (self.heat == 0) {
-        self.owner.no_active_gas_grens =
-            self.owner.no_active_gas_grens + 1;
-        if (self.owner.no_active_gas_grens > 2) {
-            te = find(world, classname, "gastimer");
-            while (te) {
-                if ((te.owner == self.owner) &&
-                        (te.no_active_gas_grens == 1)) {
-                    te.weapon = 24;
-                    te.think = RemoveGrenade;
-                    te.nextthink = time + 0.1;
-                }
-                te = find(te, classname, "gastimer");
-            }
-        }
-        self.no_active_gas_grens = self.owner.no_active_gas_grens;
-    }
     self.nextthink = time + 0.75;
     te = findradius(self.origin, 200);
     while (te != world) {
@@ -1228,7 +1208,7 @@ void () GasGrenadeMakeGas = {
             self.weapon = 0;
         return;
     }
-    RemoveGrenade();
+    dremove(self);
 };
 
 void () HallucinationTimer = {

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -2488,7 +2488,7 @@ void () TeamFortress_RemoveTimers = {
 
     te = find(world, classname, "timer");
     while (te != world) {
-        if ((te.owner == self) && (te.no_active_gas_grens <= 0)) {
+        if (te.owner == self) {
             dremove(te);
             te = find(world, classname, "timer");
         } else
@@ -2500,15 +2500,6 @@ void () TeamFortress_RemoveTimers = {
     RemovePrimeTimers();
     self.StatusGrenTime = 0;
     Status_Refresh(self);
-
-    te = find(world, classname, "grentimer");
-    while (te != world) {
-        if ((te.owner == self) && (te.no_active_napalm_grens <= 0)) {
-            dremove(te);
-            te = find(world, classname, "grentimer");
-        } else
-            te = find(te, classname, "grentimer");
-    }
 
     te = find(world, classname, "item_tfgoal");
     while (te) {
@@ -3006,7 +2997,7 @@ void () TeamFortress_ExplodePerson = {
         FO_SetModel(newmis, "progs/biggren.mdl");
     } else if (self.weapon == GR_TYPE_NAPALM) {
         newmis.touch = NapalmGrenadeTouch;
-        newmis.think = NapalmGrenadeExplode;
+        newmis.think = NapalmGrenadeExplode1;
         newmis.grenadename = "napalmgrenade";
         newmis.skin = 2;
         newmis.avelocity = '0 300 0';
@@ -3026,7 +3017,7 @@ void () TeamFortress_ExplodePerson = {
         return;
     } else if (self.weapon == GR_TYPE_GAS) {
         newmis.touch = GasGrenadeTouch;
-        newmis.think = GasGrenadeExplode;
+        newmis.think = GasGrenadeExplode1;
         newmis.grenadename = "gasgrenade";
         newmis.skin = 2;
         newmis.avelocity = '300 300 300';

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -3862,45 +3862,6 @@ void () SuperDamageSound = {
     return;
 };
 
-void () RemoveGrenade = {
-    local entity te;
-
-    if (self.no_active_napalm_grens > 0) {
-
-        self.no_active_napalm_grens = 0;
-        self.owner.no_active_napalm_grens =
-            self.owner.no_active_napalm_grens - 1;
-        if (self.owner.no_active_napalm_grens < 0)
-            self.owner.no_active_napalm_grens = 0;
-
-        te = find(world, classname, "grentimer");
-        while (te) {
-            if ((te.owner == self.owner) &&
-                    (te.no_active_napalm_grens > 0))
-                te.no_active_napalm_grens = te.no_active_napalm_grens - 1;
-            te = find(te, classname, "grentimer");
-        }
-        dremove(self.enemy);
-        dremove(self);
-    }
-    if (self.no_active_gas_grens > 0) {
-
-        self.no_active_gas_grens = 0;
-        self.owner.no_active_gas_grens =
-            self.owner.no_active_gas_grens - 1;
-        if (self.owner.no_active_gas_grens < 0)
-            self.owner.no_active_gas_grens = 0;
-
-        te = find(world, classname, "grentimer");
-        while (te) {
-            if ((te.owner == self.owner) && (te.no_active_gas_grens > 0))
-                te.no_active_gas_grens = te.no_active_gas_grens - 1;
-            te = find(te, classname, "grentimer");
-        }
-        dremove(self);
-    }
-};
-
 void () ToggleInvincibility = {
     if(self.tfstate & TFSTATE_INVINCIBLE) {
         self.items = self.items - (self.items & IT_INVULNERABILITY);


### PR DESCRIPTION
A long standing bug is that napalm grenades occasionally do not explode properly, leaving glowing, stuck entities.

This turns out to be a race between several pieces of the code.

1. When the grenade initially explodes render a flare and start a timer program for the subsequent napalm explosions ("grentimer").
2. When the program in (1) begins 100ms later, it tries to track the number of napalm (or gas) grenades active for the player in question.
3. When the player dies, conditional on there being no active napalm grenades we try to reclaim these timers.

It turns out that when (3) occurs between the 100ms between (1) and (2) that the accounting can be incorrect and we'll remove the timer, but this incorrectly eliminated the subsequent explosion and left the grenade pinned until the ent was reclaimed (since the timer also owned its removal).

There is no need for either:
  (1) The extra timer entity
  (2) The existing spam tracking

For (1) we can extend the think state machine on the existing entity for both napalm and gas, this also allows us to completely eliminate all the clean-up complexity that (3) adds [now we can just remove grenades, rather than worrying about grenades also parenting area of effect timers that we also have to remove].

We throw (2) out for now.  There are cleaner ways to write it if it's needed and it wasn't even working for gas grenades (because someone changed the timer name at some point).