### PR TITLE
Grenade timer visual tweaks

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -446,11 +446,13 @@ class CsGrenTimer;
 CsGrenTimer grentimers[NUM_GREN_TIMERS];
 
 class CsGrenTimer {
+    float index_;
     float primed_at_;
     float expires_at_;
     float flags_;
     float grentype_;
 
+    nonvirtual float() index { return index_; };
     nonvirtual float() active { return expires_at_ > time; };
     nonvirtual float() expiry { return expires_at_; };
     nonvirtual float() grentype { return grentype_; };
@@ -470,7 +472,7 @@ class CsGrenTimer {
 
     static void() Init {
         for (float i = 0; i < grentimers.length; i++)
-            grentimers[i] = spawn(CsGrenTimer);
+            grentimers[i] = spawn(CsGrenTimer, index_: i);
     };
 
     static void() StopAll {

--- a/csqc/status.qc
+++ b/csqc/status.qc
@@ -96,8 +96,8 @@ void(string panelid, float display, string text) drawSpecial = {
 };
 
 void(string panelid, float display, string text) drawGrenTimerPanel = {
-    local float timeleft;
-    local float timercount = 0;
+    float timeleft;
+    float timercount = 0;
 
     if (display) {
         FO_Hud_Panel* panel = getAnyHudPanelByNamePointer(panelid);
@@ -110,8 +110,11 @@ void(string panelid, float display, string text) drawGrenTimerPanel = {
         panel2.Display = panel.Display;
         panel2.FillSize = panel.FillSize;
 
-        for (float i = 0; i < grentimers.length; i++) {
-            local CsGrenTimer gt = grentimers[i];
+        CsGrenTimer lt = CsGrenTimer::GetLast();
+        // We want to render in reverse mod order from the last primed grenade
+        // here, that way we'll properly stack timers relative to expiry.
+        for (float i = grentimers.length; i > 0; i--) {
+            CsGrenTimer gt = grentimers[(lt.index() + i) % grentimers.length];
 
             if (!gt.active())
                 continue;
@@ -125,7 +128,11 @@ void(string panelid, float display, string text) drawGrenTimerPanel = {
                 panel2.TextScale = TextScale * 0.8;
             }
 
-            local float alpha = (gt.is_thrown()) ? 0.3 : 1.0;
+            // It's technically possible to get a primed message before thrown
+            // if things get reordered, but since we can only ever have one
+            // grenade primed, we can obscure this by always considering
+            // grenades after the first as primed.
+            float alpha = (gt.is_thrown() || timercount) ? 0.3 : 1.0;
             Hud_DrawPanelLMP(&panel2, ftos(timeleft),
                 GrenadeIcons[gt.grentype()].icon, alpha);
             panel2.Position = panel2.Position +


### PR DESCRIPTION
zel pointed out it's nicer to stack timers by expiry time when some is spamm^Whas several active simultaneously.

Also, he thought he might have seen 2 opaque timers.  This could happen momentarily if prime and throw messages are reordered, but we can actually hide this easily by always rendering stacked timers as transparent.