### PR TITLE
Default the player quad limit to off for now

### DIFF
--- a/ssqc/clan.qc
+++ b/ssqc/clan.qc
@@ -1091,7 +1091,7 @@ float () CheckAllPlayersReady = {
             bprint (2, "All players ready, starting match\n");
             StartTimer ();
 
-            local float limit_quad_players = CF_GetSetting("lqp", "limit_quad_players", "on");
+            local float limit_quad_players = CF_GetSetting("lqp", "limit_quad_players", "off");
             if (limit_quad_players) {
                 quad_maxplayers = f1;
             }


### PR DESCRIPTION
This doesn't update fast enough when clients crash and is causing problems where people can't rejoin running games quickly enough.  (More than the disruption random players were causing, which we can at least password away.)