### PR TITLE
Disable auto-assword quad code.

### DIFF
--- a/ssqc/clan.qc
+++ b/ssqc/clan.qc
@@ -1081,7 +1081,7 @@ float () CheckAllPlayersReady = {
             StartTimer ();
 
             // set default password if no password set
-            if (infokey(world, "needpass") != "1") {
+            if (FALSE && infokey(world, "needpass") != "1") {
                 local string default_password = "pineapple"; // maybe this should be configurable
                 cvar_set("password", default_password);
                 localcmd("localinfo default_password on\n");


### PR DESCRIPTION
This is locking players out with password set, while there are known interactions with 'reconnect', this also seems to include 'disconnect;password;connect'.

Only way to rejoin has been to clear the password.  Remove for now.