### PR TITLE
Fix attack_finished nits

### DIFF
--- a/ssqc/hwguy.qc
+++ b/ssqc/hwguy.qc
@@ -116,7 +116,6 @@ void FireAssCan (float shotcount, vector dir, vector spread)
     FO_WeapState ws;
     FO_FillWeapState(self, WEAP_ASSAULT_CANNON, &ws);
 
-
     Status_Refresh(self);
     FO_CheckForReload();
 

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -1791,7 +1791,10 @@ void () W_Attack = {
         W_FireLaser();
     }
 
-    if (self.current_weapon != WEAP_FLAMETHROWER)
+    if (self.current_weapon != WEAP_FLAMETHROWER &&    // Variable
+        self.current_weapon != WEAP_ASSAULT_CANNON &&  // In animation
+        self.current_weapon != WEAP_NAILGUN &&         // In animation
+        self.current_weapon != WEAP_SUPER_NAILGUN)     // In animation
         Attack_Finished(wi->attack_time);
 
     if (wi->needs_reload) {


### PR DESCRIPTION
A few weapons implement attacks via the animation code, namely the assault cannon, and both nailguns.  While this had no interaction with the nailguns, as their own animation code was setting the same attack_finished values, this was causing problems with the assault cannon that uses out of band synchronization around spin-up/spin-down.

For completeness, exclude all 3 from setting attack-finished.  At some point nailguns can probably have it pulled out of the animation code but that's a question for another day (might matter for NG more than SNG).