### PR TITLE
Fix weapon nits

### DIFF
--- a/share/fo_weapons.qc
+++ b/share/fo_weapons.qc
@@ -22,6 +22,7 @@
 float fo_hwguy = TRUE;
 float sniperreload = FALSE;
 float pyro_type = PYRO_FO;
+float old_ng_rof = FALSE;
 #endif
 
 // Convert a weapon-bit to a linear index.
@@ -78,13 +79,13 @@ FO_WeapInfo weapon_info[] = {
     { WEAP_SHOTGUN,          AMMO_SHELLS,  8, 1,  0.5,  2 },
     { WEAP_SUPER_SHOTGUN,    AMMO_SHELLS, 16, 2,  0.7,  3 },
     { WEAP_NAILGUN,          AMMO_NAILS,   0, 1,  0.2,  0 },
-    { WEAP_SUPER_NAILGUN,    AMMO_NAILS,   0, 4,  0.2,  0 },
+    { WEAP_SUPER_NAILGUN,    AMMO_NAILS,   0, 2,  0.2,  0 },
     { WEAP_GRENADE_LAUNCHER, AMMO_ROCKETS, 6, 1,  0.6,  4 },
     { WEAP_PIPE_LAUNCHER,    AMMO_NONE,    0, 1,  0.6,  4 },  // Overlaps GL
     { WEAP_FLAMETHROWER,     AMMO_CELLS,   0, 1,  0.15, 0 },
     { WEAP_ROCKET_LAUNCHER,  AMMO_ROCKETS, 4, 1,  0.8,  5 },
     { WEAP_INCENDIARY,       AMMO_ROCKETS, 0, 3, -9,    0 },
-    { WEAP_ASSAULT_CANNON,   AMMO_SHELLS, -9, 1,  0,    4 },
+    { WEAP_ASSAULT_CANNON,   AMMO_SHELLS, -9, 1,  0.2,    4 },
     { WEAP_LIGHTNING,        AMMO_CELLS,   0, 1,  0.1,  0 },
     { WEAP_DETPACK,          AMMO_NONE,    0, 0,  0,    0 },
     { WEAP_TRANQ,            AMMO_SHELLS,  0, 1,  1.5,  0 },
@@ -94,6 +95,7 @@ FO_WeapInfo weapon_info[] = {
 inline var FO_WeapInfo* FO_GetWeapInfo(float weapon) {
     return &weapon_info[WEAP_to_index(weapon)];
 }
+
 struct FO_ClassWeapons {
     float id;
     float slots[4];
@@ -104,7 +106,7 @@ struct FO_ClassWeapons {
 FO_ClassWeapons class_weapons[] = {
     { PC_UNDEFINED, { 0, 0, 0, WEAP_AXE } },
     { PC_SCOUT, { WEAP_NAILGUN, WEAP_SHOTGUN, 0, WEAP_AXE } },
-    { PC_SNIPER, { WEAP_SNIPER_RIFLE, WEAP_SNIPER_RIFLE, WEAP_NAILGUN, WEAP_AXE } },
+    { PC_SNIPER, { WEAP_SNIPER_RIFLE, WEAP_AUTO_RIFLE, WEAP_NAILGUN, WEAP_AXE } },
     { PC_SOLDIER, { WEAP_ROCKET_LAUNCHER, WEAP_SUPER_SHOTGUN, WEAP_SHOTGUN, WEAP_AXE } },
     { PC_DEMOMAN, { WEAP_GRENADE_LAUNCHER, WEAP_PIPE_LAUNCHER, WEAP_SHOTGUN, WEAP_AXE } },
     { PC_MEDIC, { WEAP_SUPER_NAILGUN, WEAP_SUPER_SHOTGUN, WEAP_SHOTGUN, WEAP_MEDIKIT } },
@@ -429,6 +431,14 @@ void FO_Weapons_Init() {
             WI_ir->attack_time = 0.9; break;
     }
 
+    // Consider just removing this?
+    if (old_ng_rof) {
+        FO_WeapInfo* wi = FO_GetWeapInfo(WEAP_NAILGUN);
+        wi->ammo_per_shot = 2;
+        FO_WeapInfo* wi = FO_GetWeapInfo(WEAP_SUPER_NAILGUN);
+        wi->ammo_per_shot = 4;
+    }
+
     float clips_allocated = 0;
     for (i = 0; i < weapon_info.length; i++) {
         FO_WeapInfo* wi = &weapon_info[i];
@@ -470,7 +480,7 @@ void FO_Weapons_Init() {
             case AMMO_NAILS: wti->ammo_mask = IT_NAILS; break;
             case AMMO_ROCKETS: wti->ammo_mask = IT_ROCKETS; break;
         }
-}
+    }
     if (clips_allocated > CLIP_STORAGE_SIZE)
         error("Insufficient clip storage");
 

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -2516,7 +2516,7 @@ void () PlayerJump = {
             self.weaponframe = 0;
             self.heat = 0;
             self.count = 1;
-            player_assaultcannondown1();
+            player_assaultcannondown();
         }
         return;
     }
@@ -2545,7 +2545,7 @@ void () PlayerJump = {
             self.weaponframe = 0;
             self.count = 1;
             self.heat = 0;
-            player_assaultcannondown1();
+            player_assaultcannondown();
         } else {
             self.tfstate = self.tfstate | TFSTATE_AIMING;
             TeamFortress_SetSpeed(self);

--- a/ssqc/player.qc
+++ b/ssqc/player.qc
@@ -387,7 +387,6 @@ void () player_nail1 =[103, player_nail2] {
         W_FireSpikes(-4);
         self.nailpos = 0;
     }
-    Attack_Finished(0.2);
 };
 
 void () player_nail2 =[104, player_nail1] {
@@ -409,185 +408,94 @@ void () player_nail2 =[104, player_nail1] {
             self.nailpos = 0;
         }
     }  
-    Attack_Finished(0.2);
 };
 
-void () player_assaultcannonup1 =[103, player_assaultcannonup2] {
-    if ((!self.button0 || (self.ammo_shells < 1)) || intermission_running) {
-        self.tfstate = self.tfstate | TFSTATE_AIMING;
+static float CheckNeedAssaultCannonDown() {
+    FO_WeapState ws;
+    FO_FillWeapState(self, WEAP_ASSAULT_CANNON, &ws);
+
+    if ((!self.button0 || (self.ammo_shells < 1)) || intermission_running ||
+        ((ws->wi)->needs_reload && *ws->clip_fired == (ws->wi)->clip_size)) {
+        self.tfstate |= TFSTATE_AIMING;
         TeamFortress_SetSpeed(self);
         self.count = 1;
-        self.heat = 0;
-        player_assaultcannondown1();
-        return;
+        player_assaultcannondown();
+        return TRUE;
     }
+    return FALSE;
+}
+void () player_assaultcannon;
+
+void () player_assaultcannonup =[103, player_assaultcannonup] {
+    if (CheckNeedAssaultCannonDown())
+        return;
+    FO_WeapInfo* wi = FO_GetWeapInfo(WEAP_ASSAULT_CANNON);
+
     self.fire_held_down = 1;
-    if (self.heat == 1) {
+    if (self.count == 0)
         FO_Sound(self, CHAN_WEAPON, "weapons/asscan1.wav", 1, 1);
-    }
+
     SuperDamageSound();
-    Attack_Finished(0.2);
-    if ((self.heat != 2) && (self.heat != 4)) {
-        if (self.weaponframe >= 3) {
-            self.weaponframe = 0;
-        } else {
-            self.weaponframe = self.weaponframe + 1;
-        }
-    }
-    self.heat = self.heat + 1;
-    if (self.heat >= 7) {
-        self.heat = 0;
-        player_assaultcannon1();
-    }
+    if ((self.heat != 2) && (self.heat != 4))
+        self.weaponframe = (self.weaponframe + 1) % 4;
+
+    if (self.count++ >= 5)  // 600ms spin up
+        player_assaultcannon();
+    else
+        Attack_Finished(wi->attack_time);
 };
 
-void () player_assaultcannonup2 =[103, player_assaultcannonup1] {
-    if ((!self.button0 || (self.ammo_shells < 1)) || intermission_running) {
-        self.tfstate = self.tfstate | TFSTATE_AIMING;
-        TeamFortress_SetSpeed(self);
-        self.count = 1;
-        self.heat = 0;
-        player_assaultcannondown1();
+void () player_assaultcannon =[103, player_assaultcannon] {
+    if (CheckNeedAssaultCannonDown())
         return;
-    }
-    SuperDamageSound();
-    Attack_Finished(0.2);
-    if (((self.heat != 2) && (self.heat != 4)) && (self.heat != 7)) {
-        if ((self.weaponframe == 2) && (self.heat >= 9)) {
-            self.weaponframe = 0;
-        } else {
-            if (self.weaponframe >= 3) {
-                self.weaponframe = 0;
-            } else {
-                self.weaponframe = self.weaponframe + 1;
-            }
+    FO_WeapInfo* wi = FO_GetWeapInfo(WEAP_ASSAULT_CANNON);
+
+    if (((vlen(self.velocity) <= 90 && !cannon_movespin) || vlen(self.velocity) < 30)
+            && !(self.tfstate & TFSTATE_LOCK)) {
+        if (self.count % 2 == 0) {
+            muzzleflash();
+            FO_Sound(self, CHAN_WEAPON, "weapons/asscan2.wav", 1, ATTN_NORM);
         }
-    }
-    self.heat = self.heat + 1;
-    if (self.heat >= 13) {
-        self.heat = 0;
-        player_assaultcannon1();
-    }
-};
-
-void () player_assaultcannon1 =[103, player_assaultcannon2] {
-    if (fo_hwguy)
-    {
-        if (self.tfstate & TFSTATE_RELOADING || self.reload_assault_cannon == PC_HVYWEAP_ASSCAN_CLIPSIZE)
-        {
-            self.count = 1;
-            player_assaultcannondown1();
-            return;
-        }
-    }
-
-    if (((vlen(self.velocity) <= 90 && !cannon_movespin) || vlen(self.velocity) <= 30)
-                && !(self.tfstate & TFSTATE_LOCK)) {
-        muzzleflash();
-        FO_Sound(self, CHAN_WEAPON, "weapons/asscan2.wav", 1, ATTN_NORM);
-
-        if (self.weaponframe == 2)
-            self.weaponframe = 4;
-        else
-            self.weaponframe = 2;
 
         SuperDamageSound();
+        self.weaponframe = self.weaponframe == 2 ? 4 : 2;
 
-        self.tfstate = self.tfstate | TFSTATE_AIMING;
+        self.tfstate |= TFSTATE_AIMING;
         if (!cannon_move)
-            self.tfstate = self.tfstate | TFSTATE_CANT_MOVE;
+            self.tfstate |= TFSTATE_CANT_MOVE;
         TeamFortress_SetSpeed(self);
 
-        W_FireAssaultCannon();
+        // Halve firing speed when moving too fast.
+        if (vlen(self.velocity) < 30 || self.count % 2 == 0)
+                W_FireAssaultCannon();
     } else {
         FO_Sound(self, CHAN_WEAPON, "weapons/asscan4.wav", 0.5, ATTN_NORM);
-
-        if (self.weaponframe == 2)
-            self.weaponframe = 0;
-        else
-            self.weaponframe = 2;
+        self.weaponframe = self.weaponframe == 2 ? 0 : 2;
     }
-    if ((!self.button0 || (self.ammo_shells < 1)) || intermission_running) {
-        self.tfstate = self.tfstate | TFSTATE_AIMING;
-        if (!cannon_move)
-            self.tfstate = self.tfstate - (self.tfstate & TFSTATE_CANT_MOVE);
-        TeamFortress_SetSpeed(self);
-        self.weaponframe = 0;
-        self.count = 1;
-        player_assaultcannondown1();
-        return;
-    }
-    Attack_Finished(0.2);
+    self.count++;
+    Attack_Finished(wi->attack_time);
 };
 
-void () player_assaultcannon2 =[104, player_assaultcannon1] {
-    if (fo_hwguy)
-    {
-        if (self.tfstate & TFSTATE_RELOADING || self.reload_assault_cannon == PC_HVYWEAP_ASSCAN_CLIPSIZE)
-        {
-            self.count = 1;
-            player_assaultcannondown1();
-            return;
-        }
-    }
-    if (vlen(self.velocity) < 30 && !(self.tfstate & TFSTATE_LOCK)) {
-        if (self.weaponframe == 2) {
-            self.weaponframe = 4;
-        } else {
-            self.weaponframe = 2;
-        }
-        SuperDamageSound();
-        W_FireAssaultCannon();
-        self.heat = self.heat + 0.1;
-    } else {
-        if (self.weaponframe == 2) {
-            self.weaponframe = 0;
-        } else {
-            self.weaponframe = 2;
-        }
-    }
-    if ((!self.button0 || (self.ammo_shells < 1)) || intermission_running) {
-        self.tfstate = self.tfstate | TFSTATE_AIMING;
-        if (!cannon_move)
-            self.tfstate = self.tfstate - (self.tfstate & TFSTATE_CANT_MOVE);
-        TeamFortress_SetSpeed(self);
-        self.weaponframe = 0;
-        self.count = 1;
-        player_assaultcannondown1();
-        return;
-    }
-    Attack_Finished(0.2);
-};
-
-void () player_assaultcannondown1 =[103, player_assaultcannondown1] {
-    if (self.count == 1) {
+void () player_assaultcannondown =[103, player_assaultcannondown] {
+    if (self.count == 0)
         FO_Sound(self, CHAN_WEAPON, "weapons/asscan3.wav", 0.8, 1);
-        self.heat = 0;
-    }
-    if (self.count >= 15) {
+    FO_WeapInfo* wi = FO_GetWeapInfo(WEAP_ASSAULT_CANNON);
+
+    if (self.count >= 14) {
         self.fire_held_down = 0;
-        self.tfstate = self.tfstate - (self.tfstate & TFSTATE_AIMING);
+        self.tfstate &= ~TFSTATE_AIMING;
         if (!cannon_move)
-            self.tfstate = self.tfstate - (self.tfstate & TFSTATE_CANT_MOVE);
+            self.tfstate &= ~TFSTATE_CANT_MOVE;
         TeamFortress_SetSpeed(self);
-        if ((self.ammo_shells < 1) || (self.ammo_cells < 7)) {
+
+        player_run();
+        if (self.ammo_cells < 7 || !FO_CheckForReload()) {
             W_PrintWeaponMessage();
             W_ChangeToBestWeapon();
-            return;
         }
-        player_run();
-        return;
-    }
-    if ((((self.count != 8) && (self.count != 10)) && (self.count != 12))
-        && (self.count != 14)) {
-        if (self.weaponframe == 3) {
-            self.weaponframe = 0;
-        } else {
-            self.weaponframe = self.weaponframe + 1;
-        }
-    }
-    self.count = self.count + 1;
-    Attack_Finished(0.2);
+    } else if (++self.count % 2 == 0)
+        self.weaponframe = (self.weaponframe + 1) % 4;
+    Attack_Finished(wi->attack_time);
 };
 
 void () player_light1 =[105, player_light2] {

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -2786,11 +2786,6 @@ void () TeamFortress_AssaultWeapon = {
     if (FO_CurrentWeaponsMask() & WEAP_ASSAULT_CANNON == 0)
         return;
 
-    if (self.heat > 0) {
-        sprint(self, PRINT_HIGH, "The Assault Cannon is still overheated\n");
-        return;
-    }
-
     if (self.ammo_shells < 1) {
         sprint(self, PRINT_HIGH, "Not enough ammo\n");
         return;

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -1374,13 +1374,12 @@ void (vector org, vector dir) launch_spike = {
 
 void () W_FireSuperSpikes = {
     local vector dir;
+    FO_WeapInfo* wi = FO_GetWeapInfo(WEAP_SUPER_NAILGUN);
 
     FO_Sound(self, CHAN_WEAPON, "weapons/spike2.wav", 1, ATTN_NORM);
 
-    if (old_ng_rof)
-        self.ammo_nails = self.ammo_nails - 4;
-    else
-        self.ammo_nails = self.ammo_nails - 2;
+    self.ammo_nails -= wi->ammo_per_shot;
+
     dir = aim(self, 1000);
     launch_spike(self.origin + '0 0 16', dir);
     LogEventAttack(self);
@@ -1389,31 +1388,33 @@ void () W_FireSuperSpikes = {
     FO_SetModel(newmis, "progs/s_spike.mdl");
     setsize(newmis, VEC_ORIGIN, VEC_ORIGIN);
     KickPlayer(-3, self);
+
+    Attack_Finished(wi->attack_time);
 };
 
 void (float ox) W_FireSpikes = {
     local vector dir;
+    FO_WeapInfo* wi = FO_GetWeapInfo(self.current_weapon);
 
     makevectors(self.v_angle);
-    if (((self.ammo_nails >= 4) || ((self.ammo_nails >= 2) && !old_ng_rof)) &&
-        (self.current_weapon == WEAP_SUPER_NAILGUN)) {
+
+    if (self.ammo_nails < wi->ammo_per_shot) {
+        W_ChangeToBestWeapon();
+        return;
+    } else if (self.current_weapon == WEAP_SUPER_NAILGUN) {
         W_FireSuperSpikes();
         return;
     }
-    if (self.ammo_nails < 1) {
-        W_ChangeToBestWeapon();
-        return;
-    }
+
     FO_Sound(self, CHAN_WEAPON, "weapons/rocket1i.wav", 1, ATTN_NORM);
-    if ((self.ammo_nails == 1) || !old_ng_rof) {
-        self.ammo_nails = self.ammo_nails - 1;
-    } else {
-        self.ammo_nails = self.ammo_nails - 2;
-    }
+    self.ammo_nails -= wi->ammo_per_shot;
+
     dir = aim(self, 1000);
     launch_spike(self.origin + '0 0 16' + v_right * ox, dir);
     LogEventAttack(self);
     KickPlayer(-3, self);
+
+    Attack_Finished(wi->attack_time);
 };
 
 void () t_climb = {
@@ -1649,9 +1650,8 @@ void () player_light1;
 void () player_rocket1;
 void () player_autorifle1;
 
-void () player_assaultcannon1;
-void () player_assaultcannonup1;
-void () player_assaultcannondown1;
+void () player_assaultcannonup;
+void () player_assaultcannondown;
 
 void () player_medikit1;
 void () player_medikitb1;
@@ -1752,12 +1752,12 @@ void () W_Attack = {
             }
             W_ChangeToBestWeapon();
         } else {
-            self.ammo_cells = self.ammo_cells - 7;
-            self.heat = 1;
+            self.ammo_cells -= - 7;
+            self.count = 0;
             self.immune_to_check = time + 5;
             self.tfstate = self.tfstate | TFSTATE_AIMING;
             TeamFortress_SetSpeed(self);
-            player_assaultcannonup1();
+            player_assaultcannonup();
         }
     } else if (self.current_weapon == WEAP_FLAMETHROWER) {
         player_shot1();
@@ -1798,7 +1798,8 @@ void () W_Attack = {
         Attack_Finished(wi->attack_time);
 
     if (wi->needs_reload) {
-        *ws->clip_fired += wi->ammo_per_shot;
+        if (self.current_weapon != WEAP_ASSAULT_CANNON)  // In animation
+            *ws->clip_fired += wi->ammo_per_shot;
         FO_CheckForReload();
     }
 


### PR DESCRIPTION
- Autorifle wasn't on the right slot for sniper
- NG/SNG had bugs in both new and old code with attack finished interactions on running out of ammo (in the old code the animation would keep generating muzzle flashes, in the new code it would stop firing but not switch).  Now properly works.
- There was a ton of spaghetti in the old hwguy cannon implementation, missing weapon switches on certain ammo cases, duplication across multiple animation functions.  Not all of this seemed to be working right so just rip it all out and rewrite it.  Seems good now.