### PR TITLE
Fix impulse 1/7

### DIFF
--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -2073,7 +2073,7 @@ static ImpulseWeapons impulse_weapons[] = {
 };
 
 float W_WeaponByImpulse(float impulse) {
-    if (impulse <= 1 || impulse >= 7) return 0;
+    if (impulse < 1 || impulse > 7) return 0;
     return impulse_weapons[self.playerclass].weapons[impulse - 1];
 }
 


### PR DESCRIPTION
We still support the old impulses when `old_weapon_impulses` is set, but the filtering was too aggressive (<=1 vs <1, same for 7).