### PR TITLE
Tie attack_finished to client_time() for now

### DIFF
--- a/share/fo_weapons.qc
+++ b/share/fo_weapons.qc
@@ -85,7 +85,7 @@ FO_WeapInfo weapon_info[] = {
     { WEAP_FLAMETHROWER,     AMMO_CELLS,   0, 1,  0.15, 0 },
     { WEAP_ROCKET_LAUNCHER,  AMMO_ROCKETS, 4, 1,  0.8,  5 },
     { WEAP_INCENDIARY,       AMMO_ROCKETS, 0, 3, -9,    0 },
-    { WEAP_ASSAULT_CANNON,   AMMO_SHELLS, -9, 1,  0.2,    4 },
+    { WEAP_ASSAULT_CANNON,   AMMO_SHELLS, -9, 1,  0.2,  4 },
     { WEAP_LIGHTNING,        AMMO_CELLS,   0, 1,  0.1,  0 },
     { WEAP_DETPACK,          AMMO_NONE,    0, 0,  0,    0 },
     { WEAP_TRANQ,            AMMO_SHELLS,  0, 1,  1.5,  0 },

--- a/ssqc/player.qc
+++ b/ssqc/player.qc
@@ -436,7 +436,7 @@ void () player_assaultcannonup =[103, player_assaultcannonup] {
         FO_Sound(self, CHAN_WEAPON, "weapons/asscan1.wav", 1, 1);
 
     SuperDamageSound();
-    if ((self.heat != 2) && (self.heat != 4))
+    if ((self.count != 2) && (self.count != 4))
         self.weaponframe = (self.weaponframe + 1) % 4;
 
     if (self.count++ >= 5)  // 600ms spin up
@@ -493,8 +493,9 @@ void () player_assaultcannondown =[103, player_assaultcannondown] {
             W_PrintWeaponMessage();
             W_ChangeToBestWeapon();
         }
-    } else if (self.count % 2 == 0)
+    } else if (self.count % 2 == 0) {
         self.weaponframe = (self.weaponframe + 1) % 4;
+    }
 
     self.count++;
     Attack_Finished(wi->attack_time);

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -202,9 +202,7 @@ void (float att_delay) Attack_Finished = {
     if (self.tfstate & TFSTATE_TRANQUILISED)
         att_delay *= 2;
 
-    // Ensure we hold firing rate constant with jitter.
-    self.attack_finished = max(client_time() + att_delay,
-                               self.attack_finished + att_delay);
+    self.attack_finished = client_time() + att_delay;
 };
 
 float () W_FireAxe = {


### PR DESCRIPTION
The prior approach failed to account for the fact that some of weapon animations have attack_finished embedded in them, resulting in overlapping calls.  This was pushing the finished time out unreasonably.

Just remove the max for now, we're going to make some other changes that will smooth out client_time in the face of jitter anyway.