### PR TITLE
Sync grenade timers with cease fire

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -467,6 +467,12 @@ class CsGrenTimer {
                     float grentype, float timer_flags) Set;
     nonvirtual void() Stop;
 
+    nonvirtual void() PauseSound {
+        if (flags_ & FL_GT_SOUND)  // -volume => stop.
+            soundupdate(this, CHAN_VOICE, "", -1, 0, 0, 0, 0);
+    };
+    nonvirtual void() StartSound;
+
     static float next_index_;
     static CsGrenTimer last_;
 
@@ -484,6 +490,19 @@ class CsGrenTimer {
         next_index_ = (next_index_ + 1) % grentimers.length;
         last_ = grentimers[next_index_];
         return last_;
+    };
+    static void() SyncPause {
+        // Time froze, but sound kept running, realign.
+        for (float i = 0; i < grentimers.length; i++)
+            if (grentimers[i].active)
+                grentimers[i].PauseSound();
+    };
+
+    static void() SyncUnpause {
+        // Time froze, but sound kept running, realign.
+        for (float i = 0; i < grentimers.length; i++)
+            if (grentimers[i].active)
+                grentimers[i].StartSound();
     };
 
     static CsGrenTimer() GetLast { return last_; };

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -317,30 +317,6 @@ string GetGrenTimerSound() {
     return wav;
 }
 
-void OldPlayGren(float offset) {
-    local float channel = CHAN_GREN_START;
-    local float soundtime;
-    local float highest_soundtime = -1;
-
-    for(float i = CHAN_GREN_START; i <= CHAN_GREN_END; i++) {
-        soundtime = getsoundtime(world, i);
-
-        if (soundtime < 0) {
-            channel = i;
-            break;
-        }
-
-        if (soundtime > highest_soundtime) {
-            highest_soundtime = soundtime;
-            channel = i;
-        }
-    }
-
-    local string wav = GetGrenTimerSound();
-    localsound(wav, channel, CVARF(FOCMD_GRENTIMERVOLUME)); // required because soundupdate doesn't reset getsoundtime
-    soundupdate(self, channel, wav, CVARF(FOCMD_GRENTIMERVOLUME), 0, 0, 0, offset);
-}
-
 void CsGrenTimer::Set(float primed_at, float expires_at, float _grentype,
                       float timer_flags) {
     grentype_ = _grentype;
@@ -377,11 +353,6 @@ void StopGrenTimers() {
     // New style.
     for (float i = 0; i < NUM_GREN_TIMERS; i++)
         grentimers[i].Stop();
-
-    // Old style.
-    for (float i = CHAN_GREN_START; i <= CHAN_GREN_END; i++) {
-        soundupdate(self, i, "", 0, 0, 0, 0, 0);
-    }
 }
 
 void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
@@ -400,19 +371,9 @@ void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
     }
 
     float debug_print_state = CVARF(fo_grentimer_debug) & 1;
-    float debug_use_old_sound = CVARF(fo_grentimer_debug) & 4;
-
-    float play_old_sound = FALSE;
-    if (debug_use_old_sound) {
-        play_old_sound = timer_flags & FL_GT_SOUND;
-        timer_flags &= ~FL_GT_SOUND;
-    }
 
     CsGrenTimer timer = CsGrenTimer::GetNext();
     timer.Set(primed_at, explodes_at, grentype, timer_flags);
-
-    if (play_old_sound)
-        OldPlayGren(timer.sound_offset());
 
     if (debug_print_state) {
         float ping = getplayerkeyfloat(player_localnum, INFOKEY_P_PING) / 1000;
@@ -421,11 +382,8 @@ void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
         float expires_new = timer.expiry();
         float expires_ideal = explodes_at - ping/2;
 
-        print(sprintf("primed_at=%0.2f explodes_at=%0.2f fuse=%0.2f new=%d\n",
-                    primed_at, explodes_at, explodes_at - primed_at,
-                    !debug_use_old_sound));
-        print(sprintf("ideal=%0.2f new=%0.2f old=%0.2f\n",
-                expires_ideal, expires_new, expires_old));
+        print(sprintf("primed_at=%0.2f explodes_at=%0.2f fuse=%0.2f\n",
+                      primed_at, explodes_at, explodes_at - primed_at));
     }
 }
 

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -301,6 +301,12 @@ void() CSQC_Parse_Event = {
         case MSG_VOTE_MAP_DELETE:
             RemoveVoteMap(readstring(), FALSE);
             break;
+        case MSG_PAUSE:
+            CsGrenTimer::SyncPause();
+            break;
+        case MSG_UNPAUSE:
+            CsGrenTimer::SyncUnpause();
+            break;
     }
 }
 
@@ -317,6 +323,18 @@ string GetGrenTimerSound() {
     return wav;
 }
 
+void CsGrenTimer::StartSound() {
+    if !(this.flags_ & FL_GT_SOUND)
+        return;
+
+    string wav = GetGrenTimerSound();
+    float volume = CVARF(FOCMD_GRENTIMERVOLUME);
+
+    // Note there's a bug where soundupdate returns false for a new sample, even
+    // though it's started.
+    soundupdate(this, CHAN_VOICE, wav, volume, 0, 0, 0, sound_offset());
+}
+
 void CsGrenTimer::Set(float primed_at, float expires_at, float _grentype,
                       float timer_flags) {
     grentype_ = _grentype;
@@ -330,22 +348,12 @@ void CsGrenTimer::Set(float primed_at, float expires_at, float _grentype,
         expires_at_ -= rtt/2;
     }
 
-    if !(this.flags_ & FL_GT_SOUND)
-        return;
-
-    string wav = GetGrenTimerSound();
-    float volume = CVARF(FOCMD_GRENTIMERVOLUME);
-
-    // Note there's a bug where soundupdate returns false for a new sample, even
-    // though it's started.
-    soundupdate(this, CHAN_VOICE, wav, volume, 0, 0, 0, sound_offset());
+    StartSound();
 }
-
 
 void CsGrenTimer::Stop() {
     expires_at_ = -1;
-    if (flags_ & FL_GT_SOUND)
-        soundupdate(this, CHAN_VOICE, "", -1, 0, 0, 0, 0);  // -volume => stop.
+    PauseSound();  // Pause is really stop.
     flags_ = 0;
 }
 

--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -32,6 +32,8 @@
 #define MSG_VOTE_MAP_ADD    20
 #define MSG_VOTE_MAP_DELETE 21
 #define MSG_PLAYERDIE       22
+#define MSG_PAUSE           23
+#define MSG_UNPAUSE         24
 
 #define FLAGINFO_HOME       1
 #define FLAGINFO_CARRIED    2

--- a/ssqc/admin.qc
+++ b/ssqc/admin.qc
@@ -187,9 +187,25 @@ void () Admin_CeaseFire = {
     }
 };
 
+void NotifyPauseUnpause(float is_pause) {
+    entity p = find (world, classname, "player");
+    while (p) {
+        if (p.netname == "" || !infokeyf(p, INFOKEY_P_CSQCACTIVE))
+            continue;
+
+        msg_entity = p;
+        WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
+        WriteByte(MSG_MULTICAST, is_pause ? MSG_PAUSE : MSG_UNPAUSE);
+        multicast('0 0 0', MULTICAST_ONE_R_NOSPECS);
+
+        p = find(p, classname, "player");
+    }
+}
+
 void () Admin_Pause = {
     if (!is_paused) {
         setpause(1);
+        NotifyPauseUnpause(TRUE);
         is_paused = 1;
         cs_paused = 1;
         pause_actor = self.netname;

--- a/ssqc/mvdsv.qc
+++ b/ssqc/mvdsv.qc
@@ -107,6 +107,7 @@ void (float duration) GE_PausedTic = {
     local entity p;
     if (unpause_requested && (unpause_countdown == 0)) {
         unpause_countdown = duration + 5;
+        unpause_lastcountnumber = 5;
     }
     if (unpause_requested) {
         if ((duration >= unpause_countdown)) {
@@ -116,56 +117,20 @@ void (float duration) GE_PausedTic = {
             unpause_requested = 0;
             unpause_lastcountnumber = 0;
             setpause(0);
-        }
-        else  {
-            if (duration >= (unpause_countdown - 4) && (unpause_lastcountnumber == 0)) {           
-                unpause_lastcountnumber = 4;
-                p = find (world, classname, "player");
-                while (p) {
-                    if (p.netname != "") {
-                        stuffcmd(p, "play buttons/switch04.wav\n");
-                    }
-                    p = find(p, classname, "player");
-                }                    
-                bprint(PRINT_HIGH, "Unpausing in 4 seconds\n" );
-                
+            NotifyPauseUnpause(FALSE);
+        } else if (duration >= unpause_countdown - (unpause_lastcountnumber)) {
+            unpause_lastcountnumber--;
+            p = find (world, classname, "player");
+            while (p) {
+                if (p.netname != "")
+                    stuffcmd(p, "play buttons/switch04.wav\n");
+                p = find(p, classname, "player");
             }
-            else if (duration >= (unpause_countdown - 3) && (unpause_lastcountnumber == 4)) {
-                unpause_lastcountnumber = 3;
-                p = find (world, classname, "player");
-                while (p) {
-                    if (p.netname != "") {
-                        stuffcmd(p, "play buttons/switch04.wav\n");
-                    }
-                    p = find(p, classname, "player");
-                }
-                bprint(PRINT_HIGH, "Unpausing in 3 seconds\n" );                
-            }
-            else if (duration >= (unpause_countdown - 2) && (unpause_lastcountnumber == 3)) {
-                unpause_lastcountnumber = 2;
-                p = find (world, classname, "player");
-                while (p) {
-                    if (p.netname != "") {
-                        stuffcmd(p, "play buttons/switch04.wav\n");
-                    }
-                    p = find(p, classname, "player");
-                }
-                bprint(PRINT_HIGH, "Unpausing in 2 seconds\n" );
-            }
-            else if (duration >= (unpause_countdown - 1) && (unpause_lastcountnumber == 2)) {
-                unpause_lastcountnumber = 1;
-                p = find (world, classname, "player");
-                while (p) {
-                    if (p.netname != "") {
-                        stuffcmd(p, "play buttons/switch04.wav\n");
-                    }
-                    p = find(p, classname, "player");
-                }
-                bprint(PRINT_HIGH, "Unpausing in 1 second\n" );
-            }
+            bprint(PRINT_HIGH,
+                   sprintf("Unpausing in %d seconds\n", unpause_lastcountnumber));
         }
     }
-}   
+}
 
 void(float pauseduration) SV_PausedTic = {
     GE_PausedTic(pauseduration);


### PR DESCRIPTION
It's rather frustrating that ceasefire causes all the active grenade
timers to lose sync (the visual timer pauses, but the sound just keeps
playing).  Implement actual pause/unpause of the timer sound around
ceasefire start/end.
