### PR TITLE
Make sure ReloadSlot checks for not a nullslot

### DIFF
--- a/share/fo_weapons.qc
+++ b/share/fo_weapons.qc
@@ -364,7 +364,7 @@ float FO_CanReload(Slot slot) {
 void () RestoreDefaultWeapon;
 void FO_ReloadSlot(Slot slot, float force) {
     RestoreDefaultWeapon();
-    if (self.tfstate & TFSTATE_RELOADING)
+    if (self.tfstate & TFSTATE_RELOADING || IsSlotNull(slot))
         return;
 
     FO_WeapState ws;


### PR DESCRIPTION
Generically called from impulse commands, could be no weapon.