### PR TITLE
Spawn with SlotNull not Melee

### DIFF
--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -2075,7 +2075,7 @@ void () PutClientInServer = {
     self.display_tip = 0;
     self.tip_type = 0;
 
-    self.current_slot = SlotMelee;
+    self.current_slot = SlotNull;
     FO_InstantReloadAllWeapons(self);
 
     self.immune_to_check = time + 10;


### PR DESCRIPTION
This was intended as a conservative state reset but it triggers other last selected weapon logic later and results in always spawning with axe, Null's a more correct choice anyway.