### PR TITLE
Fix Ammo table

### DIFF
--- a/share/fo_weapons.qc
+++ b/share/fo_weapons.qc
@@ -194,7 +194,7 @@ static FO_WeapModels weapon_models[] = {
 };
 
 // REQUIRES: Order must match above.
-static string AMMO_to_s[] = {"shells", "cells", "nails" "rockets", "grenades"};
+static string AMMO_to_s[] = {"none", "shells", "nails", "cells", "rockets"};
 
 static float* AMMO_to_p(entity player, AmmoType ammo_type) {
     switch (ammo_type) {

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -2075,7 +2075,6 @@ void () PutClientInServer = {
     self.display_tip = 0;
     self.tip_type = 0;
 
-    self.current_slot = SlotNull;
     FO_InstantReloadAllWeapons(self);
 
     self.immune_to_check = time + 10;


### PR DESCRIPTION
A missing comma was resulting in silent string concatenation and a table size of
4.  This was leading to OOB references that looked like they were on slots but were really on ammo.

Originally I was going to restore grenades as an ammo type here (with flavour text) as well but other stuff is yielding a message first so will look at that later.