### PR TITLE
Re-enable projectile matching for SNG

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -520,10 +520,10 @@ void PP_NailFrame() {
     if (!IsEffectFrame())
         return;
 
-    float off = 0;
-    if (wi->weapon == WEAP_NAILGUN)  // Else: SNG, no offset.
-        off = idx ? 4 : -4;
-    PP_CreateProjectile(&fpp_types[FPP_NAIL], v_right * off);
+    if (wi->weapon == WEAP_NAILGUN)
+        PP_CreateProjectile(&fpp_types[FPP_NAIL], v_right * (idx ? 4: - 4));
+    else
+        PP_CreateProjectile(&fpp_types[FPP_SUPER_NAIL], '0 0 0');
 }
 
 void WP_Attack() {

--- a/share/weapon_predict.qc
+++ b/share/weapon_predict.qc
@@ -55,6 +55,7 @@ enum {
     FPP_ROCKET,
     FPP_INCENDIARY,
     FPP_NAIL,
+    FPP_SUPER_NAIL,
     FPP_FLAMETHROWER,
 };
 
@@ -73,6 +74,7 @@ fo_projectile fpp_types[] = {
     { FPP_ROCKET,     PC_SOLDIER_ROCKET_SPEED, "progs/missile.mdl", "" },
     { FPP_INCENDIARY,         800, "progs/lavaball.mdl", "t_lavaball" },
     { FPP_NAIL,              1500, "progs/spike.mdl", "tr_spike" },
+    { FPP_SUPER_NAIL,        1500, "progs/s_spike.mdl", "tr_spike" },
     { FPP_FLAMETHROWER,       600, "progs/s_explod.spr", "explodesprite" },
 };
 


### PR DESCRIPTION
It needs its own type because projectile is a different model.