### PR TITLE
Big tfstate cleanup

### DIFF
--- a/share/animate.qc
+++ b/share/animate.qc
@@ -4,9 +4,10 @@ struct anim_t {
     int weaponframes[9];
     int muzzle_flash;  // muzzle flash on weaponframe index 0
     int loop;
+    int freeze_last_frame; // used for feigning death
 };
 
-static void think_nop() {}
+void think_nop() {}
 
 #ifdef SSQC
 
@@ -25,7 +26,6 @@ int W_FireSpanner();
 
 void SuperDamageSound();
 void FO_Sound(entity e, float chan, string samp, float vol, float atten);
-void TeamFortress_SetSpeed(entity p);
 
 void player_run();
 void player_stand1();
@@ -51,9 +51,11 @@ void client_anim_frames(void() parent_thunk, void() extra, anim_t* anim) {
         muzzleflash();
 
     int fi = tidx % anim->num_frames;
+    if (tidx >= anim->num_frames && anim->freeze_last_frame)
+        fi = anim->num_frames - 1;
     self.frame = anim->frames[fi] ?: anim->frames[0] + fi;
 
-    if (fi == anim->num_frames - 1 && !anim->loop)
+    if (fi == anim->num_frames - 1 && !anim->loop && !anim->freeze_last_frame)
         FO_SetClientThink(player_run, 0.1);
     else
         FO_SetClientThink(parent_thunk, 0.1);
@@ -119,7 +121,6 @@ static float CheckNeedAssaultCannonDown() {
     if ((!self.button0 || (self.ammo_shells < 1)) || intermission_running ||
         ((ws->wi)->needs_reload && *ws->clip_fired == (ws->wi)->clip_size)) {
         self.tfstate |= TFSTATE_AIMING;
-        TeamFortress_SetSpeed(self);
         player_asscan_down1();
         return TRUE;
     }
@@ -130,6 +131,7 @@ void asscan_up_extra() {
     if (CheckNeedAssaultCannonDown())
         return;
 
+    self.tfstate |= TFSTATE_AIMING;
     FO_WeapInfo* wi = FO_GetWeapInfo(WEAP_ASSAULT_CANNON);
 
     self.fire_held_down = 1;
@@ -162,10 +164,9 @@ void asscan_fire_extra() {
         self.tfstate |= TFSTATE_AIMING;
         if (!cannon_move)
             self.tfstate |= TFSTATE_CANT_MOVE;
-        TeamFortress_SetSpeed(self);
 
         // Halve firing speed when moving too fast.
-        if (vlen(self.velocity) < 30 || self.count % 2 == 0)
+        if (vlen(self.velocity) < 30 || self.client_thinkindex % 2 == 1)
                 W_FireAssaultCannon();
     } else {
         FO_Sound(self, CHAN_WEAPON, "weapons/asscan4.wav", 0.5, ATTN_NORM);
@@ -182,7 +183,6 @@ void asscan_down_extra() {
 
     if (self.client_thinkindex >= 15) {  // 1.5s down
         self.tfstate &= ~TFSTATE_AIMING;
-        TeamFortress_SetSpeed(self);
         self.fire_held_down = 0;
         player_run();
         if (self.ammo_cells < 7 || !FO_CheckForReload()) {

--- a/share/defs.h
+++ b/share/defs.h
@@ -241,27 +241,31 @@
 //===========================================================================
 
 // TeamFortress State Flags
-#define TFSTATE_GRENPRIMED		1   // Whether the player has a primed grenade
-#define TFSTATE_RELOADING		2   // Whether the player is reloading
-#define TFSTATE_ALTKILL			4   // TRUE if killed with a weapon not in self.weapon: NOT USED ANYMORE
-#define TFSTATE_RANDOMPC		8   // Whether Playerclass is random, new one each respawn
-#define TFSTATE_INFECTED		16  // set when player is infected by the bioweapon
-#define TFSTATE_INVINCIBLE		32  // Player has permanent Invincibility (Usually by GoalItem)
-#define TFSTATE_INVISIBLE		64  // Player has permanent Invisibility (Usually by GoalItem)
-#define TFSTATE_QUAD			128 // Player has permanent Quad Damage (Usually by GoalItem)
-#define TFSTATE_RADSUIT			256 // Player has permanent Radsuit (Usually by GoalItem)
-#define TFSTATE_BURNING			512 // Is on fire
-#define TFSTATE_GRENTHROWING		1024  // is throwing a grenade
-#define TFSTATE_AIMING			2048  // is using the laser sight
-#define TFSTATE_LOCK            4096 // this state will stop hwguy from shooting assault cannon
-#define TFSTATE_RESPAWN_READY		8192  // is waiting for respawn, and has pressed fire, as sentry gun, indicate it needs to die
-#define TFSTATE_HALLUCINATING		16384  // set when player is hallucinating
-#define TFSTATE_TRANQUILISED 		32768  // set when player is tranquilised
-#define TFSTATE_CANT_MOVE		65536  // set when player is setting a detpack
-// FIXME - concussion and flash states aren't set or tested...
-#define TFSTATE_FLAMES_MAX		131072
-#define TFSTATE_FLASHED			262144
-#define TFSTATE_CONCUSSED		524288
+enumflags {
+    TFSTATE_GRENPRIMED,    // Whether the player has a primed grenade
+    TFSTATE_RELOADING,     // Whether the player is reloading
+    TFSTATE_AIMING,        // is using the laser sight or spinning
+    TFSTATE_CANT_MOVE,
+    TFSTATE_NO_WEAPON,     // Weapon is disabled and not visible (e.g. detpack)
+                           // (Note: We don't use NO_WEAPON for reloading
+                           // as it could result in stacked no-weapon states.)
+    TFSTATE_INFECTED,      // set when player is infected by the bioweapon
+    TFSTATE_INVINCIBLE,    // Player has permanent Invincibility (Usually by GoalItem)
+    TFSTATE_INVISIBLE,     // Player has permanent Invisibility (Usually by GoalItem)
+    TFSTATE_QUAD,          // Player has permanent Quad Damage (Usually by GoalItem)
+    TFSTATE_RADSUIT,       // Player has permanent Radsuit (Usually by GoalItem)
+    TFSTATE_BURNING,       // Is on fire
+    TFSTATE_GRENTHROWING,  // is throwing a grenade
+    TFSTATE_LOCK,          // assault cannon locked
+    TFSTATE_RESPAWN_READY, // is waiting for respawn, and has pressed fire,
+                           // as sentry gun,indicate it needs to die
+    TFSTATE_HALLUCINATING, // set when player is hallucinating
+    TFSTATE_TRANQUILISED,  // set when player is tranquilised
+    TFSTATE_FLAMES_MAX,    // Peak burnination.
+    TFSTATE_RANDOMPC,      // Whether Playerclass is random, new one each respawn
+};
+
+#define TFSTATE_AC_MASK (TFSTATE_AC_SPINUP|TFSTATE_AC_SPINNING|TFSTATE_AC_SPINDOWN)
 
 // Defines used by TF_T_Damage (see combat.qc)
 #define TF_TD_IGNOREARMOR	1  // Bypasses the armor of the target

--- a/share/weapon_predict.qc
+++ b/share/weapon_predict.qc
@@ -448,7 +448,7 @@ void WP_UpdateViewModel() {
 
     }
 
-    if (WP_IsReloading()) {
+    if (pstate_pred.tfstate & (TFSTATE_NO_WEAPON | TFSTATE_RELOADING)) {
         self.modelindex = 0;
         return;
     }

--- a/share/weapons.qc
+++ b/share/weapons.qc
@@ -375,7 +375,7 @@ void (float att_delay) Attack_Finished;
 
 // Hack until we fix Status_Refresh() to not be awful.
 .float last_still_loading;
-void W_UpdateCurrentWeapon(entity pl);;
+void W_UpdateCurrentWeapon(entity pl);
 
 void FO_ReloadFrame() {
     if (self.tfstate & TFSTATE_RELOADING == 0)
@@ -445,8 +445,6 @@ void FO_ReloadSlot(Slot slot, float force) {
 
     Attack_Finished(wi->attack_time);  // Carried.. but not sure it's necessary.
 
-    self.weaponmodel = "";
-    self.weaponframe = 0;
     self.tfstate |= TFSTATE_RELOADING;
     Status_Refresh(self);
 

--- a/ssqc/admin.qc
+++ b/ssqc/admin.qc
@@ -152,8 +152,7 @@ void () Admin_CeaseFire = {
         while (te) {
             CenterPrint3(te, "CEASE FIRE\nCalled by: ", self.netname, "\n");
             te.immune_to_check = (time + 5);
-            te.tfstate = (te.tfstate | TFSTATE_CANT_MOVE);
-            TeamFortress_SetSpeed(te);
+            te.tfstate |= TFSTATE_CANT_MOVE;
             te = find(te, classname, "player");
         }
         te = spawn();
@@ -180,8 +179,7 @@ void () Admin_CeaseFire = {
         while (te) {
             CenterPrint3(te, "RESUME FIRE\nCalled by: ", self.netname, "\n");
             te.immune_to_check = (time + 5);
-            te.tfstate = (te.tfstate - (te.tfstate & TFSTATE_CANT_MOVE));
-            TeamFortress_SetSpeed (te);
+            te.tfstate &= ~TFSTATE_CANT_MOVE;
             te = find (te, classname, "player");
         }
     }

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -1688,7 +1688,7 @@ void () ClientKill = {
     set_suicide_frame();
     self.modelindex = modelindex_player;
 
-    self.weaponmodel = "";
+    self.tfstate |= TFSTATE_NO_WEAPON;
     self.view_ofs = '0 0 -8';
     self.movetype = MOVETYPE_NONE;
     TeamFortress_RemoveTimers();
@@ -2251,8 +2251,7 @@ void () PutClientInServer = {
     if (cease_fire) {
         sprint(self, PRINT_HIGH, "\n\nCease fire mode\n");
         self.immune_to_check = time + 10;
-        self.tfstate = self.tfstate | TFSTATE_CANT_MOVE;
-        TeamFortress_SetSpeed(self);
+        self.tfstate |= TFSTATE_CANT_MOVE;
     }
 
     if (self.playerclass == 0 && self.team_no > 0) {
@@ -2524,8 +2523,7 @@ void () PlayerJump = {
             }
             StopAssCan();
         } else {
-            self.tfstate = self.tfstate | TFSTATE_AIMING;
-            TeamFortress_SetSpeed(self);
+            self.tfstate |= TFSTATE_AIMING;
         }
     }
 
@@ -2713,8 +2711,7 @@ void () PlayerPreThink = {
                     self.feign_areachecked = 1;
                     if (!(self.tfstate & TFSTATE_CANT_MOVE)) {
                         self.movetype = MOVETYPE_NONE;
-                        self.tfstate = self.tfstate | TFSTATE_CANT_MOVE;
-                        TeamFortress_SetSpeed(self);
+                        self.tfstate |= TFSTATE_CANT_MOVE;
                     }
                 }
             }
@@ -2911,6 +2908,19 @@ void () CheckPowerups = {
     }
 };
 
+void FO_HandleTFStateUpdate() {
+    if (self.last_tfstate == self.tfstate)
+        return;
+
+    float state_changed = self.last_tfstate ^ self.tfstate;
+    if (state_changed & TFSTATE_NO_WEAPON)
+        W_UpdateWeaponModel(self);
+    if (state_changed & (TFSTATE_AIMING | TFSTATE_CANT_MOVE | TFSTATE_TRANQUILISED))
+        TeamFortress_SetSpeed(self);
+
+    self.last_tfstate = self.tfstate;
+}
+
 void () PlayerPostThink = {
     FO_CheckClientThink();
     UpdateScoreboardInfo(self);
@@ -2962,16 +2972,12 @@ void () PlayerPostThink = {
         }
     }
     self.jump_flag = self.velocity_z;
-    
-    if(votemode) {
-        if (time >= self.StatusRefreshTime)
-            RefreshStatusBar(self);
 
+    if(votemode) {
         CheckPowerups();
         FO_ReloadFrame();
         W_WeaponFrame();
         //TeamFortress_CheckforCheats();
-        //TeamFortress_SetSpeed(self);
     } else {
         CheckPowerups();
         FO_ReloadFrame();
@@ -2984,13 +2990,15 @@ void () PlayerPostThink = {
                 self.cheat_check = time + 5;
             }
         }
-        if (time >= self.StatusRefreshTime)
-            RefreshStatusBar(self);
         if (self.cheat_check <= time) {
             TeamFortress_CheckTeamCheats();
             self.cheat_check = time + 3;
         }
     }
+
+    FO_HandleTFStateUpdate();
+    if (time >= self.StatusRefreshTime)
+        RefreshStatusBar(self);
 };
 
 void () UpdateAllClientsTeamScores = {

--- a/ssqc/demoman.qc
+++ b/ssqc/demoman.qc
@@ -218,12 +218,9 @@ void (float timer) TeamFortress_SetDetpack = {
     self.detpack_left = timer;
     self.ammo_detpack = self.ammo_detpack - 1;
     self.immune_to_check = time + 10;
-    self.tfstate = self.tfstate | TFSTATE_CANT_MOVE;
-
-    W_QueueAndDisableWeapon();
+    self.tfstate |= TFSTATE_CANT_MOVE | TFSTATE_NO_WEAPON;
 
     Status_Refresh(self);
-    TeamFortress_SetSpeed(self);
 
     self.pausetime = time + 3;
     stimer = ftos(timer);
@@ -256,12 +253,11 @@ void () TeamFortress_DetpackStop = {
     self.ammo_detpack = self.ammo_detpack + 1;
     dremove(detpack_timer);
 
-    self.tfstate = self.tfstate - (self.tfstate & TFSTATE_CANT_MOVE);
-    self.is_detpacking = 0;  // Weapon is queued.
+    self.is_detpacking = 0;
+    self.tfstate &= ~(TFSTATE_CANT_MOVE | TFSTATE_NO_WEAPON);
     self.detpack_left = 0;
 
     Status_Refresh(self);
-    TeamFortress_SetSpeed(self);
     self.pausetime = time;
 };
 
@@ -278,8 +274,7 @@ void () TeamFortress_DetpackSet = {
 
     self.owner.is_detpacking = 0;
     Menu_Close(self.owner);
-    self.owner.tfstate = self.owner.tfstate - (self.owner.tfstate & TFSTATE_CANT_MOVE);
-    TeamFortress_SetSpeed(self.owner);
+    self.owner.tfstate &= ~(TFSTATE_CANT_MOVE | TFSTATE_NO_WEAPON);
     FO_Sound(self.owner, CHAN_VOICE, "doors/medtry.wav", 1, ATTN_NORM);
     oldself = self;
     self = self.owner;
@@ -401,7 +396,6 @@ void () TeamFortress_DetpackExplode = {
         sprint(self.owner, PRINT_HIGH, "Your detpack fizzled out\n");
 
     if (self.is_disarming) {
-        TeamFortress_SetSpeed(self.enemy);
         dremove(self.oldenemy);
         dremove(self.observer_list);
     }
@@ -439,11 +433,9 @@ void () TeamFortress_DetpackTouch = {
     }
 
     other.immune_to_check = time + 5;
-    other.tfstate = other.tfstate | TFSTATE_CANT_MOVE;
+    other.tfstate |= (TFSTATE_CANT_MOVE | TFSTATE_NO_WEAPON);
 
     sprint(other, PRINT_HIGH, "Disarming detpack...\n");
-
-    TeamFortress_SetSpeed(other);
 
     disarm = spawn();
     disarm.owner = other;
@@ -464,9 +456,8 @@ void () TeamFortress_DetpackDisarm = {
     }
     bprint(PRINT_MEDIUM, self.enemy.owner.netname,
            "'s detpack was defused by ", self.owner.netname, "\n");
-    self.owner.tfstate = self.owner.tfstate - (self.owner.tfstate & TFSTATE_CANT_MOVE);
+    self.owner.tfstate &= ~(TFSTATE_CANT_MOVE | TFSTATE_NO_WEAPON);
     TF_AddFrags(self.owner, 1);
-    TeamFortress_SetSpeed(self.owner);
     self.enemy.owner.detpack_left = 0;
     Status_Refresh(self.enemy.owner);
 

--- a/ssqc/engineer.qc
+++ b/ssqc/engineer.qc
@@ -402,10 +402,8 @@ void () TeamFortress_EngineerBuildStop = {
     self.is_building = 0;
     self.building_percentage = 0;
     if (!engineer_move) {
-        self.tfstate &= ~TFSTATE_CANT_MOVE;
+        self.tfstate &= ~(TFSTATE_CANT_MOVE | TFSTATE_NO_WEAPON);
         self.movetype = MOVETYPE_WALK;
-        TeamFortress_SetSpeed(self);
-        // Old weapon already queued.
     }
 }
 
@@ -553,11 +551,9 @@ void (float objtobuild) TeamFortress_Build = {
     self.is_building = 1;
     if (!engineer_move) {
         self.immune_to_check = time + 5;
-        self.tfstate = self.tfstate | TFSTATE_CANT_MOVE;
+        self.tfstate |= TFSTATE_CANT_MOVE | TFSTATE_NO_WEAPON;
         self.movetype = MOVETYPE_NONE;
 
-        W_QueueAndDisableWeapon();
-        TeamFortress_SetSpeed(self);
         Menu_Engineer_Cancel();
     }
 
@@ -904,10 +900,8 @@ void () TeamFortress_FinishedBuilding = {
     self.is_building = FALSE;
     self.building_percentage = 0;
     if (!engineer_move) {
-        self.tfstate &= ~TFSTATE_CANT_MOVE;
+        self.tfstate &= ~(TFSTATE_CANT_MOVE | TFSTATE_NO_WEAPON);
         self.movetype = MOVETYPE_WALK;
-        TeamFortress_SetSpeed(self);
-        // Weapon should be queued.
     }
     Status_Refresh(self);
 

--- a/ssqc/hwguy.qc
+++ b/ssqc/hwguy.qc
@@ -145,9 +145,6 @@ void FireAssCan (float shotcount, vector dir, vector spread)
 void StopAssCan() {
     if (self.fire_held_down && (FO_CurrentWeapon() == WEAP_ASSAULT_CANNON)) {
 	self.tfstate = self.tfstate | TFSTATE_AIMING;
-	TeamFortress_SetSpeed(self);
-	self.tfstate = self.tfstate - (self.tfstate & TFSTATE_CANT_MOVE);
-	TeamFortress_SetSpeed(self);
 	//self.weaponframe = 0;
 	player_asscan_down1();
     }

--- a/ssqc/player.qc
+++ b/ssqc/player.qc
@@ -465,7 +465,7 @@ void () PlayerDie = {
     if (deathmatch || coop)
         DropBackpack();
 
-    self.weaponmodel = "";
+    self.tfstate |= TFSTATE_NO_WEAPON;
     self.view_ofs = '0 0 -8';
     self.deadflag = DEAD_DYING;
     self.solid = SOLID_NOT;

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -110,6 +110,7 @@ float remote_client_time(float ct_type = CT_NOEXTERNALEFFECT);
 .entity nopickup;               // Don't pick up this backpack/ammobox because it doesn't contain any of your ammo types
 
 .float tfstate;                 // State flags for TeamFortress
+.float last_tfstate;             // Internal cache of tfstate for detecting updates
 .entity linked_list;            // Used just like chain. Has to be separate so
                                 // it doesn't interfere with chain. See T_RadiusScan
 

--- a/ssqc/scout.qc
+++ b/ssqc/scout.qc
@@ -225,7 +225,7 @@ void FO_FlashExplode()
         if (te.classname == "player") {
             traceline(self.origin, te.origin, 1, self);
             if (trace_fraction == 1) {
-                LogEventAffliction(self.owner, te, TFSTATE_FLASHED);
+                // LogEventAffliction(self.owner, te, TFSTATE_FLASHED);
                 sprint(te, PRINT_HIGH, "You have been flashed!\n");
                 org = te.origin + (te.mins + te.maxs) * 0.5;
                 frac = (rad - vlen(self.origin - org)) / rad;
@@ -303,7 +303,7 @@ void () FlashGrenadeExplode = {
             if (te.classname == "player") {
                 traceline(self.origin, te.origin, 1, self);
                 if (trace_fraction == 1) {
-                    LogEventAffliction(self.owner, te, TFSTATE_FLASHED);
+                    // LogEventAffliction(self.owner, te, TFSTATE_FLASHED);
                     if (vlen(self.origin - te.origin) <= 200) {
                         deathmsg = DMSG_GREN_FLASH;
                         TF_T_Damage(te, self, self.owner, 60, 2, 16 | 4);
@@ -894,7 +894,7 @@ void (entity inflictor, entity attacker, float bounce,
                                 te.nextthink = time + 0.25;
                             }
                         } else {
-                            LogEventAffliction(attacker, head, TFSTATE_CONCUSSED);
+                            // LogEventAffliction(attacker, head, TFSTATE_CONCUSSED);
                             if (old_grens == TRUE) {
                                 stuffcmd(head, "v_idlescale 100\n");
                                 stuffcmd(head, "fov 130\n");

--- a/ssqc/sniper.qc
+++ b/ssqc/sniper.qc
@@ -121,9 +121,7 @@ void () SniperSight_Update = {
     if (!(self.owner.tfstate & TFSTATE_AIMING) ||
         (FO_PlayerCurrentWeapon(self.owner) != WEAP_SNIPER_RIFLE)) {
 
-        self.owner.tfstate =
-            self.owner.tfstate - (self.owner.tfstate & TFSTATE_AIMING);
-        TeamFortress_SetSpeed(self.owner);
+        self.owner.tfstate &= ~TFSTATE_AIMING;
         self.owner.heat = 0;
         dremove(self);
         return;

--- a/ssqc/spy.qc
+++ b/ssqc/spy.qc
@@ -5,353 +5,57 @@ void () T_TranqDartTouch;
 void () Spy_DropBackpack;
 void (entity targ, entity attacker) KillSound;
 
-void () spy_diea1 =[50, spy_diea2] {
-};
-
-void () spy_diea2 =[51, spy_diea3] {
-};
-
-void () spy_diea3 =[52, spy_diea4] {
-};
-
-void () spy_diea4 =[53, spy_diea5] {
-};
-
-void () spy_diea5 =[54, spy_diea6] {
-};
-
-void () spy_diea6 =[55, spy_diea7] {
-};
-
-void () spy_diea7 =[56, spy_diea8] {
-};
-
-void () spy_diea8 =[57, spy_diea9] {
-};
-
-void () spy_diea9 =[58, spy_diea10] {
-};
-
-void () spy_diea10 =[59, spy_diea11] {
-};
-
-void () spy_diea11 =[60, spy_diea11] {
-};
-
-void () spy_dieb1 =[61, spy_dieb2] {
-};
-
-void () spy_dieb2 =[62, spy_dieb3] {
-};
-
-void () spy_dieb3 =[63, spy_dieb4] {
-};
-
-void () spy_dieb4 =[64, spy_dieb5] {
-};
-
-void () spy_dieb5 =[65, spy_dieb6] {
-};
-
-void () spy_dieb6 =[66, spy_dieb7] {
-};
-
-void () spy_dieb7 =[67, spy_dieb8] {
-};
-
-void () spy_dieb8 =[68, spy_dieb9] {
-};
-
-void () spy_dieb9 =[69, spy_dieb9] {
-};
-
-void () spy_diec1 =[70, spy_diec2] {
-};
-
-void () spy_diec2 =[71, spy_diec3] {
-};
-
-void () spy_diec3 =[72, spy_diec4] {
-};
-
-void () spy_diec4 =[73, spy_diec5] {
-};
-
-void () spy_diec5 =[74, spy_diec6] {
-};
-
-void () spy_diec6 =[75, spy_diec7] {
-};
-
-void () spy_diec7 =[76, spy_diec8] {
-};
-
-void () spy_diec8 =[77, spy_diec9] {
-};
-
-void () spy_diec9 =[78, spy_diec10] {
-};
-
-void () spy_diec10 =[79, spy_diec11] {
-};
-
-void () spy_diec11 =[80, spy_diec12] {
-};
-
-void () spy_diec12 =[81, spy_diec13] {
-};
-
-void () spy_diec13 =[82, spy_diec14] {
-};
-
-void () spy_diec14 =[83, spy_diec15] {
-};
-
-void () spy_diec15 =[84, spy_diec15] {
-};
-
-void () spy_died1 =[85, spy_died2] {
-};
-
-void () spy_died2 =[86, spy_died3] {
-};
-
-void () spy_died3 =[87, spy_died4] {
-};
-
-void () spy_died4 =[88, spy_died5] {
-};
-
-void () spy_died5 =[89, spy_died6] {
-};
-
-void () spy_died6 =[90, spy_died7] {
-};
-
-void () spy_died7 =[91, spy_died8] {
-};
-
-void () spy_died8 =[92, spy_died9] {
-};
-
-void () spy_died9 =[93, spy_died9] {
-};
-
-void () spy_diee1 =[94, spy_diee2] {
-};
-
-void () spy_diee2 =[95, spy_diee3] {
-};
-
-void () spy_diee3 =[96, spy_diee4] {
-};
-
-void () spy_diee4 =[97, spy_diee5] {
-};
-
-void () spy_diee5 =[98, spy_diee6] {
-};
-
-void () spy_diee6 =[99, spy_diee7] {
-};
-
-void () spy_diee7 =[100, spy_diee8] {
-};
-
-void () spy_diee8 =[101, spy_diee9] {
-};
-
-void () spy_diee9 =[102, spy_diee9] {
-};
-
-void () spy_die_ax1 =[41, spy_die_ax2] {
-};
-
-void () spy_die_ax2 =[42, spy_die_ax3] {
-};
-
-void () spy_die_ax3 =[43, spy_die_ax4] {
-};
-
-void () spy_die_ax4 =[44, spy_die_ax5] {
-};
-
-void () spy_die_ax5 =[45, spy_die_ax6] {
-};
-
-void () spy_die_ax6 =[46, spy_die_ax7] {
-};
-
-void () spy_die_ax7 =[47, spy_die_ax8] {
-};
-
-void () spy_die_ax8 =[48, spy_die_ax9] {
-};
-
-void () spy_die_ax9 =[49, spy_die_ax9] {
-};
-
-void () spy_upb1 =[69, spy_upb2] {
-};
-
-void () spy_upb2 =[68, spy_upb3] {
-};
-
-void () spy_upb3 =[67, spy_upb4] {
-};
-
-void () spy_upb4 =[66, spy_upb5] {
-};
-
-void () spy_upb5 =[65, spy_upb6] {
-};
-
-void () spy_upb6 =[64, spy_upb7] {
-};
-
-void () spy_upb7 =[63, spy_upb8] {
-};
-
-void () spy_upb8 =[62, spy_upb9] {
-};
-
-void () spy_upb9 =[61, spy_upb9] {
-    player_stand1();
-};
-
-void () spy_upc1 =[84, spy_upc2] {
-};
-
-void () spy_upc2 =[83, spy_upc3] {
-};
-
-void () spy_upc3 =[82, spy_upc4] {
-};
-
-void () spy_upc4 =[81, spy_upc5] {
-};
-
-void () spy_upc5 =[80, spy_upc6] {
-};
-
-void () spy_upc6 =[79, spy_upc7] {
-};
-
-void () spy_upc7 =[78, spy_upc8] {
-};
-
-void () spy_upc8 =[77, spy_upc9] {
-};
-
-void () spy_upc9 =[76, spy_upc10] {
-};
-
-void () spy_upc10 =[75, spy_upc11] {
-};
-
-void () spy_upc11 =[74, spy_upc12] {
-};
-
-void () spy_upc12 =[73, spy_upc13] {
-};
-
-void () spy_upc13 =[72, spy_upc14] {
-};
-
-void () spy_upc14 =[71, spy_upc15] {
-};
-
-void () spy_upc15 =[70, spy_upc15] {
-    player_stand1();
-};
-
-void () spy_upd1 =[93, spy_upd2] {
-};
-
-void () spy_upd2 =[92, spy_upd3] {
-};
-
-void () spy_upd3 =[91, spy_upd4] {
-};
-
-void () spy_upd4 =[90, spy_upd5] {
-};
-
-void () spy_upd5 =[89, spy_upd6] {
-};
-
-void () spy_upd6 =[88, spy_upd7] {
-};
-
-void () spy_upd7 =[87, spy_upd8] {
-};
-
-void () spy_upd8 =[86, spy_upd9] {
-};
-
-void () spy_upd9 =[85, spy_upd9] {
-    player_stand1();
-};
-
-void () spy_upe1 =[94, spy_upe9] {
-};
-
-void () spy_upe9;
-void () spy_upe2 =[95, spy_upe8] {
-};
-
-void () spy_upe8;
-void () spy_upe3 =[96, spy_upe7] {
-};
-
-void () spy_upe7;
-void () spy_upe4 =[97, spy_upe6] {
-};
-
-void () spy_upe6;
-void () spy_upe5 =[98, spy_upe5] {
-};
-
-void () spy_upe6 =[99, spy_upe4] {
-};
-
-void () spy_upe7 =[100, spy_upe3] {
-};
-
-void () spy_upe8 =[101, spy_upe2] {
-};
-
-void () spy_upe9 =[102, spy_upe1] {
-    player_stand1();
-};
-
-void () spy_upaxe1 =[49, spy_upaxe2] {
-};
-
-void () spy_upaxe2 =[48, spy_upaxe3] {
-};
-
-void () spy_upaxe3 =[47, spy_upaxe4] {
-};
-
-void () spy_upaxe4 =[46, spy_upaxe5] {
-};
-
-void () spy_upaxe5 =[45, spy_upaxe6] {
-};
-
-void () spy_upaxe6 =[44, spy_upaxe7] {
-};
-
-void () spy_upaxe7 =[43, spy_upaxe8] {
-};
-
-void () spy_upaxe8 =[42, spy_upaxe9] {
-};
-
-void () spy_upaxe9 =[41, spy_upaxe9] {
-    player_stand1();
-};
+anim_t anim_spy_diea1 = { 11, 1, {50}, {0}, FALSE, FALSE, TRUE };
+void spy_dieaN() { client_anim_frames(spy_dieaN, think_nop, &anim_spy_diea1); }
+void spy_diea1() { *thinkindex() = 1; spy_dieaN(); }
+
+anim_t anim_spy_dieb1 = { 9, 1, {61}, {0}, FALSE, FALSE, TRUE };
+void spy_diebN() { client_anim_frames(spy_diebN, think_nop, &anim_spy_dieb1); }
+void spy_dieb1() { *thinkindex() = 1; spy_diebN(); }
+
+anim_t anim_spy_diec1 = { 15, 1, {70}, {0}, FALSE, FALSE, TRUE };
+void spy_diecN() { client_anim_frames(spy_diecN, think_nop, &anim_spy_diec1); }
+void spy_diec1() { *thinkindex() = 1; spy_diecN(); }
+
+anim_t anim_spy_died1 = { 9, 1, {85}, {0}, FALSE, FALSE, TRUE };
+void spy_diedN() { client_anim_frames(spy_diedN, think_nop, &anim_spy_died1); }
+void spy_died1() { *thinkindex() = 1; spy_diedN(); }
+
+anim_t anim_spy_diee1 = { 9, 1, {94}, {0}, FALSE, FALSE, TRUE };
+void spy_dieeN() { client_anim_frames(spy_dieeN, think_nop, &anim_spy_diee1); }
+void spy_diee1() { *thinkindex() = 1; spy_dieeN(); }
+
+anim_t anim_spy_die_ax1 = { 9, 1, {41}, {0}, FALSE, FALSE, TRUE };
+void spy_die_axN() { client_anim_frames(spy_die_axN, think_nop, &anim_spy_die_ax1); }
+void spy_die_ax1() { *thinkindex() = 1; spy_die_axN(); }
+
+void spy_up_extra() {
+    // Death animations are variable length, this always picks up last frame.
+    // Animation transition to stand would take an extra 100ms.
+    if (self.client_think == player_run)
+        player_stand1();
+}
+
+anim_t anim_spy_upb1 = { 9, 1, {69, 68, 67, 66, 65, 64, 63, 62, 61}, {0}, FALSE, FALSE };
+void spy_upbN() { client_anim_frames(spy_upbN, spy_up_extra, &anim_spy_upb1); }
+void spy_upb1() { *thinkindex() = 1; spy_upbN(); }
+
+anim_t anim_spy_upc1 =
+    { 15, 1, {84,83,82,81,80,79,78,77,76,75,74,73,72,71,70}, {0}, FALSE, FALSE };
+void spy_upcN() { client_anim_frames(spy_upcN, spy_up_extra, &anim_spy_upc1); }
+void spy_upc1() { *thinkindex() = 1; spy_upcN(); }
+
+anim_t anim_spy_upd1 = { 9, 1, {93, 92, 91, 90, 89, 88, 87, 86, 85}, {0}, FALSE, FALSE };
+void spy_updN() { client_anim_frames(spy_updN, spy_up_extra, &anim_spy_upd1); }
+void spy_upd1() { *thinkindex() = 1; spy_updN(); }
+
+anim_t anim_spy_upe1 = { 9, 1, {102, 101, 100, 99, 98, 97, 96, 95, 94}, {0}, FALSE, FALSE };
+void spy_upeN() { client_anim_frames(spy_upeN, spy_up_extra, &anim_spy_upe1); }
+void spy_upe1() { *thinkindex() = 1; spy_upeN(); }
+
+anim_t anim_spy_upaxe1 = { 9, 1, {49, 48, 47, 46, 45, 44, 43, 32, 41}, {0}, FALSE, FALSE };
+void spy_upaxeN() { client_anim_frames(spy_upaxeN, spy_up_extra, &anim_spy_upaxe1); }
+void spy_upaxe1() { *thinkindex() = 1; spy_upaxeN(); }
 
 float (entity pe_player) Spy_CheckArea = {
     local entity at_spot = findradius(pe_player.origin, 64);
@@ -379,10 +83,8 @@ void (entity pe_player, float dontstopdead) Spy_CheckForFuncTouch = {
             pe_player.velocity_y = 0;
             pe_player.movetype = MOVETYPE_TOSS;
             //This is needed for plats that have a virtual presence and this causes you to fall slowly when inside it
-            if(!dontstopdead) {
-                pe_player.tfstate = pe_player.tfstate | TFSTATE_CANT_MOVE;
-                TeamFortress_SetSpeed(pe_player);
-            }
+            if(!dontstopdead)
+                pe_player.tfstate |= TFSTATE_CANT_MOVE;
         }
     }
 };
@@ -393,7 +95,7 @@ void () CF_Spy_AirThink = {
     if(self.owner.deadflag >= 2) {
         // reset the movetype just in case you die while in the TOSS or the WALK states (eg mbasesr lift squish)
         self.owner.movetype = MOVETYPE_NONE;
-        self.owner.tfstate = self.owner.tfstate | TFSTATE_CANT_MOVE;
+        self.owner.tfstate |= TFSTATE_CANT_MOVE;
         dremove(self);
         return;
     }
@@ -418,7 +120,7 @@ void () CF_Spy_AirThink = {
                 } else {
                     self.owner.movetype = MOVETYPE_NONE;
                 }
-                self.owner.tfstate = self.owner.tfstate | TFSTATE_CANT_MOVE;
+                self.owner.tfstate |= TFSTATE_CANT_MOVE;
             }
         }
 
@@ -426,9 +128,6 @@ void () CF_Spy_AirThink = {
         else {
             self.owner.movetype = MOVETYPE_TOSS;
         }
-
-        TeamFortress_SetSpeed(self.owner);
-
     }
 
     self.nextthink = time + 0.1;
@@ -498,7 +197,7 @@ void (float issilent, float force) FO_Spy_Feign = {
     setsize(self, '-16 -16 -24', '16 16 -16');
 
     // set weapon state and remove weapon viewmodel
-    W_QueueAndDisableWeapon();
+    self.tfstate |= TFSTATE_NO_WEAPON;
 
     // set view height to ground
     self.view_ofs = '0 0 4';
@@ -543,7 +242,7 @@ void (float issilent, float force) FO_Spy_Feign = {
     }
 
     // die with axe equipped if carrying axe, medikit, knife or spanner
-    if (self.weapon <= WEAP_AXE) {
+    if (IsSlotMelee(self.current_slot)) {
         spy_die_ax1();
         return;
     }
@@ -605,8 +304,7 @@ void () FO_Spy_Unfeign = {
 
         // allow spy to move again
         self.movetype = MOVETYPE_WALK;
-        self.tfstate = self.tfstate - (self.tfstate & TFSTATE_CANT_MOVE);
-        TeamFortress_SetSpeed(self);
+        self.tfstate &= ~(TFSTATE_CANT_MOVE | TFSTATE_NO_WEAPON);
 
         // set revive animation
         local float i;
@@ -1428,14 +1126,13 @@ void () T_TranqDartTouch = {
                 }
             } else {
                 sprint(other, 2, "You feel tired...\n");
-                other.tfstate = other.tfstate | TFSTATE_TRANQUILISED;
+                other.tfstate |= TFSTATE_TRANQUILISED;
                 timer = spawn();
                 timer.nextthink = time + 15;
                 timer.think = TranquiliserTimer;
                 timer.classname = "timer";
                 timer.owner = other;
                 timer.team_no = self.owner.team_no;
-                TeamFortress_SetSpeed(other);
             }
         }
         spawn_touchblood(9);
@@ -1461,8 +1158,7 @@ void () T_TranqDartTouch = {
 };
 
 void () TranquiliserTimer = {
-    self.owner.tfstate = self.owner.tfstate - (self.owner.tfstate & TFSTATE_TRANQUILISED);
-    TeamFortress_SetSpeed(self.owner);
+    self.owner.tfstate &= ~TFSTATE_TRANQUILISED;
     sprint(self.owner, PRINT_HIGH, "You feel more alert now\n");
     dremove(self);
 };

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -344,8 +344,7 @@ void (float inp) TeamFortress_ChangeClass = {
     if (cease_fire) {
         sprint(self, PRINT_HIGH, "\n\nCease fire mode\n");
         self.immune_to_check = time + 10;
-        self.tfstate = self.tfstate | TFSTATE_CANT_MOVE;
-        TeamFortress_SetSpeed(self);
+        self.tfstate |= TFSTATE_CANT_MOVE;
     }
     self.spawn_time = time;
 
@@ -1286,7 +1285,7 @@ void (entity p) TeamFortress_SetSpeed = {
     local entity te;
 
     stuffcmd(p, "cl_movespeedkey 1\n");
-    if (p.tfstate & TFSTATE_CANT_MOVE || (p.is_building == 1 && !engineer_move) || p.is_detpacking > 0) {
+    if (p.tfstate & TFSTATE_CANT_MOVE) {
 #ifdef STOP_MOUSE_MOVEMENT
         stuffcmd(p, "m_forward 0\n");
         stuffcmd(p, "m_side 0\n");
@@ -1379,16 +1378,8 @@ void (entity p) TeamFortress_SetSpeed = {
         }
     }
     sp = ftos(p.maxfbspeed);
-    stuffcmd(p, "cl_backspeed ");
-    stuffcmd(p, sp);
-    stuffcmd(p, "\n");
-    stuffcmd(p, "cl_forwardspeed ");
-    stuffcmd(p, sp);
-    stuffcmd(p, "\n");
-    sp = ftos(p.maxstrafespeed);
-    stuffcmd(p, "cl_sidespeed ");
-    stuffcmd(p, sp);
-    stuffcmd(p, "\n");
+    stuffcmd(p, "cl_backspeed ", sp, "; cl_forwardspeed ", sp,
+                "; cl_sidespeed ", sp, "\n");
     p.maxspeed = p.maxfbspeed;
 };
 
@@ -2236,8 +2227,8 @@ void () TeamFortress_SetEquipment = {
 
     if (self.last_playerclass != self.playerclass)
         W_ChangeToBestWeapon();
-    else
-        W_UpdateCurrentWeapon(self);
+
+    W_UpdateCurrentWeapon(self);
     self.last_playerclass = self.playerclass;
 };
 
@@ -2356,8 +2347,7 @@ void () TeamFortress_RemoveTimers = {
     self.is_building = 0;
     self.building = world;
     if (self.tfstate & TFSTATE_AIMING) {
-        self.tfstate = self.tfstate - TFSTATE_AIMING;
-        TeamFortress_SetSpeed(self);
+        self.tfstate &= ~TFSTATE_AIMING;
         self.heat = 0;
     }
     if (self.tfstate & TFSTATE_INFECTED)
@@ -3213,8 +3203,7 @@ void (entity p) KickCheater = {
     p.touch = SUB_Null;
     p.health = 0;
     p.solid = SOLID_NOT;
-    p.tfstate = p.tfstate | TFSTATE_CANT_MOVE;
-    TeamFortress_SetSpeed(p);
+    p.tfstate |= TFSTATE_CANT_MOVE;
     TeamFortress_RemoveTimers();
 };
 

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -478,10 +478,7 @@ int () W_FireMedikit = {
 
                     if (te != world) {
 
-                        trace_ent.tfstate =
-                            trace_ent.tfstate -
-                            (trace_ent.tfstate & TFSTATE_TRANQUILISED);
-                        TeamFortress_SetSpeed(trace_ent);
+                        trace_ent.tfstate &= ~TFSTATE_TRANQUILISED;
                         SpawnBlood(org, 20);
 
                         bprint(PRINT_MEDIUM, self.netname, " healed ",
@@ -1552,6 +1549,17 @@ void () superspike_touch = {
     dremove(self);
 };
 
+void W_UpdateWeaponModel(entity pl) {
+    FO_WeapState ws;
+    FO_FillWeapState(pl, pl.current_slot, &ws);
+    FO_WeapInfo* wi = ws.wi;
+
+    if (pl.tfstate & (TFSTATE_RELOADING | TFSTATE_NO_WEAPON) == 0)
+        pl.weaponmodel = (wi->models)->model;
+    else
+        pl.weaponmodel = "";
+}
+
 void (entity pl) W_UpdateCurrentWeapon = {
     entity oldself;
 
@@ -1567,11 +1575,7 @@ void (entity pl) W_UpdateCurrentWeapon = {
     pl.items |= (wi->items)->ammo_mask;
     pl.weapon = (wi->items)->it_weapon;
 
-    if ((pl.tfstate & TFSTATE_RELOADING == 0) && !pl.is_feigning &&
-        !pl.is_detpacking) {
-        pl.weaponmodel = (wi->models)->model;
-    } else
-        pl.weaponmodel = "";
+    W_UpdateWeaponModel(pl);
     pl.weaponframe = 0;
 
     // refresh engineer build menu when ammo updated
@@ -1632,7 +1636,8 @@ void () W_Attack = {
     if (self.has_disconnected == TRUE)
         return;
 
-    if (self.tfstate & TFSTATE_RELOADING || self.is_detpacking)
+    if (self.tfstate & TFSTATE_RELOADING ||
+        self.tfstate & TFSTATE_NO_WEAPON)
         return;
 
     if (no_fire_mode)
@@ -1720,8 +1725,7 @@ void () W_Attack = {
             self.ammo_cells -= - 7;
             self.count = 0;
             self.immune_to_check = time + 5;
-            self.tfstate = self.tfstate | TFSTATE_AIMING;
-            TeamFortress_SetSpeed(self);
+            self.tfstate |= TFSTATE_AIMING;
             player_asscan_up1();
         }
     } else if (ws.weapon == WEAP_FLAMETHROWER) {
@@ -1775,7 +1779,7 @@ void () W_Attack = {
 
 float WeaponReady() {
     if (self.client_time >= self.attack_finished &&
-        !(self.tfstate & TFSTATE_RELOADING))
+        !(self.tfstate & (TFSTATE_RELOADING | TFSTATE_NO_WEAPON)))
         return TRUE;
 
     return FALSE;
@@ -1885,19 +1889,12 @@ void W_ChangeWeaponByInput(float input) {
     W_ChangeWeaponSlot(slot);
 }
 
-void W_QueueAndDisableWeapon() {
-    self.queue_slot = self.current_slot;
-    // We don't want to actually call Update/Change since that could affect what
-    // other players see.  Caller should be setting some state that holds back
-    // the queue (e.g. feigned).
-    self.current_slot = SlotNull;
-    self.weaponmodel = "";
-    self.weaponframe = 0;
-}
-
 void W_ChangeWeaponSlot(Slot slot) {
     if (self.playerclass == 0)
         return;
+
+    if (!IsSlotNull(slot))
+        slot = MakeSlot(1);
 
     FO_WeapState ws;
     FO_FillWeapState(self, slot, &ws);
@@ -1975,17 +1972,13 @@ Slot W_FindPrevNextWeaponSlot(Slot slot, float is_prev) {
 }
 
 void W_ChangeWeaponNext() {
-    if (self.weaponmodel == string_null || IsSlotNull(self.current_slot))
-        return;
-
-    W_ChangeWeaponSlot(W_FindPrevNextWeaponSlot(self.current_slot, FALSE));
+    Slot slot = IsSlotNull(self.current_slot) ? MakeSlot(1) : self.current_slot;
+    W_ChangeWeaponSlot(W_FindPrevNextWeaponSlot(slot, FALSE));
 }
 
 void W_ChangeWeaponPrev() {
-    if (self.weaponmodel == string_null || IsSlotNull(self.current_slot))
-        return;
-
-    W_ChangeWeaponSlot(W_FindPrevNextWeaponSlot(self.current_slot, TRUE));
+    Slot slot = IsSlotNull(self.current_slot) ? MakeSlot(1) : self.current_slot;
+    W_ChangeWeaponSlot(W_FindPrevNextWeaponSlot(slot, TRUE));
 }
 
 void () PreMatchImpulses;
@@ -2044,7 +2037,7 @@ void () ImpulseCommands = {
     } else if (self.impulse == TF_TOGGLEVOTE)
         Vote_ToggleMenu(self);
 
-    if ((!self.is_building && !self.is_detpacking) && !self.is_feigning) {
+    if (self.tfstate & TFSTATE_NO_WEAPON == 0) {
         if (self.impulse == TF_WEAPNEXT)
             W_ChangeWeaponNext();
         else if (self.impulse == TF_WEAPPREV)
@@ -2067,11 +2060,10 @@ void () ImpulseCommands = {
             TeamFortress_SetDetpack(50);
         else if (self.impulse == TF_DROP_AMMO) {
             Menu_Drop();
-        }
-	else if (self.impulse == TF_PRACSPAWN_PLACE)
-		TeamFortress_PlacePracticeSpawn(self);
-	else if (self.impulse == TF_PRACSPAWN_REMOVE)
-		TeamFortress_RemovePracticeSpawn(self);
+        } else if (self.impulse == TF_PRACSPAWN_PLACE)
+            TeamFortress_PlacePracticeSpawn(self);
+        else if (self.impulse == TF_PRACSPAWN_REMOVE)
+            TeamFortress_RemovePracticeSpawn(self);
     }
 
     if (self.impulse == TF_INVENTORY)
@@ -2129,9 +2121,9 @@ void () ImpulseCommands = {
             Menu_Spy_Skin();
     } else if ((self.impulse == TF_SPY_DIE) && (self.playerclass == PC_SPY))
         FO_Spy_FeignCmd(0);
-    else if ((self.impulse == TF_SPY_DIE_ON) && (self.playerclass == PC_SPY)) {
+    else if ((self.impulse == TF_SPY_DIE_ON) && (self.playerclass == PC_SPY))
         FO_Spy_FeignOnNextDamage();
-    } else if ((self.impulse == TF_SPY_SILENT_DIE) && (self.playerclass == PC_SPY))
+    else if ((self.impulse == TF_SPY_SILENT_DIE) && (self.playerclass == PC_SPY))
         FO_Spy_FeignCmd(1);
     else if (self.impulse == TF_DISGUISE_RESET && self.playerclass == PC_SPY) {
         CF_Spy_ChangeSkin(self, 8, TRUE);
@@ -2571,7 +2563,6 @@ void () W_WeaponFrame = {
         return;
     }
 
-
     if ((self.is_feigning) &&
             (self.impulse != TF_SPECIAL_SKILL) &&
             (self.impulse != TF_SPECIAL_SKILL_2) &&
@@ -2593,8 +2584,7 @@ void () W_WeaponFrame = {
     if (self.impulse == TF_QUICKSTOP)
         self.impulse = self.qf_swap_last_slot ? TF_WEAPLAST : 0;
 
-    float can_change_weapon = WeaponReady() &&
-        !self.is_detpacking && !(self.is_building && !engineer_move);
+    float can_change_weapon = WeaponReady();
 
     // TODO: Open up queueing by moving queue can_change to ChangeWeapon?
     if (self.impulse >= 1 && self.impulse <= GetMaxWeaponInput() &&
@@ -2687,6 +2677,10 @@ void () W_WeaponFrame = {
         case TF_CHANGEPC_RANDOM:
         case TF_INVENTORY:
         case FLAG_INFO:
+        case TF_SPY_DIE:
+        case TF_SPY_DIE_ON:
+        case TF_SPY_DIE_OFF:
+        case TF_SPY_SILENT_DIE:
             ImpulseCommands();
             return;
             // allows setting detpack while reloading on toggle, defaults to off
@@ -2738,9 +2732,8 @@ void () W_WeaponFrame = {
                 if (vlen(tv) <= 50) {
                     SniperSight_Create();
                     self.heat = 50;
-                    self.tfstate = self.tfstate | 2048;
+                    self.tfstate |= TFSTATE_AIMING;
                     self.power_full = 0;
-                    TeamFortress_SetSpeed(self);
                 }
             }
         } else if (FO_CurrentWeapon() == WEAP_ASSAULT_CANNON) {
@@ -2757,12 +2750,7 @@ void () W_WeaponFrame = {
         }
     } else if (self.tfstate & TFSTATE_AIMING) {
         W_Attack();
-        self.tfstate = self.tfstate - TFSTATE_AIMING;
-        TeamFortress_SetSpeed(self);
-        self.heat = 0;
-    } else if (self.tfstate & TFSTATE_CANT_MOVE && !self.is_feigning) {
-        self.tfstate = self.tfstate - TFSTATE_CANT_MOVE;
-        TeamFortress_SetSpeed(self);
+        self.tfstate &= ~TFSTATE_AIMING;
         self.heat = 0;
     }
 };


### PR DESCRIPTION
- Introduce TFSTATE_NO_WEAPON to handle cases where firing is disabled (e.g. detpack, feign, etc).  This both standardizes behaviors and allows prediction sync.
- Migrate TFSTATE flags to enumflags, remove a bunch of stale ones
- Move speed synchronization into Think (triggered off changes in tfstate) rather than trying to make SetSpeeds.
- Fix a bug where heavy could fire too fast while moving.
- Fix several bug with feign (new and old)