### PR TITLE
Turn on weapon prediction by default

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1,12 +1,12 @@
 DEFCVAR_FLOAT(wpp_debug, 0);
 
 
-DEFCVAR_FLOAT(fo_wp_minping, 40);
+DEFCVAR_FLOAT(fo_wp_minping, 50);
 DEFCVAR_FLOAT(fo_weap_predict, -1);
 DEFCVAR_FLOAT(fo_proj_predict, -1);
 
 float default_proj_predict = TRUE;
-float default_weap_predict = FALSE;
+float default_weap_predict = TRUE;
 
 void WP_UpdateViewModel(entity pweap_ent);
 


### PR DESCRIPTION
Originally was separating this but it's behaving fairly well with latest updates and turns out to actually matter for projectiles (since otherwise you can change weapons fast enough that client still thinks you are using previous weapon and creates incorrect predicted projectiles).

Could possibly separate tracking and rendering in the future but goal is to just make this unnecessary and always automatically on.