### PR TITLE
Match client-side sound with animation

### DIFF
--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -524,12 +524,16 @@ void ParseSBAR()
     }
 }
 
-float(float entnum, float channel, string soundname, float vol, float attenuation, vector pos, float pitchmod) CSQC_Event_Sound = {
-    // Filter out sounds we may have generated locally, unless we're just
-    // pretending to be that entity.
-    if (entnum != player_localentnum || is_spectator || is_observer)
+float(float ent_num, float channel, string soundname, float vol, float attenuation, vector pos, float pitchmod) CSQC_Event_Sound = {
+    // Sound sent to our predicted weapon is expected to have been client-side.
+    if (ent_num == pengine.pweap_ent.entnum)
+        return 1;
+
+    // Sounds from remote entities are not local and we should always play.
+    if (ent_num != player_localentnum || is_spectator || is_observer)
         return 0;
 
+    // Sounds below this line are conditionally filtered.
     switch(soundname) {
         case "player/plyrjmp8.wav":
         case "player/land.wav":

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -172,6 +172,20 @@ static void SetHadEffect() {
 ////////////////////////////////////////////////////////////////////////////////
 float animate_s_time;
 
+static entity pred_sound_entity;
+
+void Pred_Sound(int snd) {
+    if (pstate_pred.tfstate & TFSTATE_FLASHED)
+        return;
+
+    setorigin(pred_sound_entity, pmove_org);
+    sound(pred_sound_entity, CHAN_WEAPON, snd_types[snd].sound, 1, ATTN_NORM);
+}
+
+void PredProj_Sound(int proj_type) {
+    Pred_Sound(fpp_types[proj_type].snd);
+}
+
 inline FO_WeapInfo* WP_CurrentWeapon() {
     return FO_SlotWeapInfo(pstate_pred.playerclass, pstate_pred.current_slot);
 }
@@ -530,6 +544,9 @@ float nail_trail;
 static float corr_s;  // Auto-tuning correction factor.
 
 void FO_PP_Init() {
+    // Entity we'll attach locally generated sound to.
+    pred_sound_entity = spawn();
+
     InitFppProjectiles();
 
     for (float i = 0; i < trail_table.length; i++) {
@@ -662,7 +679,11 @@ static float PP_EPS = 0.05;
 
 DEFCVAR_FLOAT(cl_r2g, 0);
 
-void PP_CreateProjectile(fo_projectile* desc, vector offset) {
+void PP_CreateProjectile(int proj_type, vector offset) {
+  fo_projectile* desc = &fpp_types[proj_type];
+
+  PredProj_Sound(proj_type);
+
   SetHadEffect();
   entity proj = spawn();
 
@@ -729,9 +750,9 @@ void PP_NailFrame() {
         return;
 
     if (wi->weapon == WEAP_NAILGUN)
-        PP_CreateProjectile(&fpp_types[FPP_NAIL], v_right * (idx ? 4: - 4));
+        PP_CreateProjectile(FPP_NAIL, v_right * (idx ? 4: - 4));
     else
-        PP_CreateProjectile(&fpp_types[FPP_SUPER_NAIL], '0 0 0');
+        PP_CreateProjectile(FPP_SUPER_NAIL, '0 0 0');
 }
 
 void WP_Attack() {
@@ -758,20 +779,30 @@ void WP_Attack() {
     if (PP_Enabled() && IsEffectFrame() && !in_anim) {
         switch (wi->weapon) {
             case WEAP_ROCKET_LAUNCHER:
-                PP_CreateProjectile(&fpp_types[FPP_ROCKET], v_forward * 8);
+                PP_CreateProjectile(FPP_ROCKET, v_forward * 8);
                 break;
             case WEAP_INCENDIARY:
-                PP_CreateProjectile(&fpp_types[FPP_INCENDIARY], v_forward * 8);
+                PP_CreateProjectile(FPP_INCENDIARY, v_forward * 8);
                 break;
             case WEAP_FLAMETHROWER:
-                PP_CreateProjectile(&fpp_types[FPP_FLAMETHROWER], v_forward * 16);
+                PP_CreateProjectile(FPP_FLAMETHROWER, v_forward * 16);
                 break;
             case WEAP_TRANQ:
-                PP_CreateProjectile(&fpp_types[FPP_TRANQ], v_forward * 8);
+                PP_CreateProjectile(FPP_TRANQ, v_forward * 8);
                 break;
             case WEAP_RAILGUN:
-                PP_CreateProjectile(&fpp_types[FPP_RAILGUN], '0 0 0');
+                PP_CreateProjectile(FPP_RAILGUN, '0 0 0');
                 break;
+            case WEAP_GRENADE_LAUNCHER:
+            case WEAP_PIPE_LAUNCHER:
+                Pred_Sound(SND_GREN); break;
+            case WEAP_AXE:
+            case WEAP_KNIFE:
+            case WEAP_SPANNER:
+            case WEAP_MEDIKIT:
+                Pred_Sound(SND_AXE); break;
+            case WEAP_SHOTGUN: Pred_Sound(SND_SG); break;
+            case WEAP_SUPER_SHOTGUN: Pred_Sound(SND_SSG); break;
         }
     }
 
@@ -847,6 +878,14 @@ float PredProjectile_MatchProjectile() {
     return FALSE;
 }
 
+static int Proj_FindFPP(entity ent) {
+    for (float i = 0; i < fpp_types.length; i++) {
+        if (fpp_types[i].modelindex == ent.server_modelindex)
+            return i;
+    }
+    return -1;
+}
+
 // Called on `self`.
 void InitProjPredEnt() {
     self.drawmask = MASK_ENGINE;
@@ -866,8 +905,11 @@ void InitProjPredEnt() {
     // We still check this with projectile prediction as there could be in
     // flight projectiles on the transition.  This is effectively a nop in the
     // off case since the projectile list will just be empty.
-    if (self.owner_entnum == player_localentnum)
-       PredProjectile_MatchProjectile();
+    if (self.owner_entnum == player_localentnum &&
+        !PredProjectile_MatchProjectile()) {
+        // Missing projectile implies we missed the local sound, patch it up.
+        PredProj_Sound(Proj_FindFPP(self));
+    }
 }
 
 DEFCVAR_FLOAT(r_drawviewmodel, 1);
@@ -890,8 +932,8 @@ void WP_UpdateViewModel(entity pweap_ent) {
         pengine.view_mask &= ~MASK_VIEWMODEL;
     }
 
-    if (pstate_pred.tfstate & (TFSTATE_NO_WEAPON | TFSTATE_RELOADING) ||
-        CVARF(r_drawviewmodel) == 0) {
+    static float no_weap_mask = TFSTATE_NO_WEAPON | TFSTATE_RELOADING | TFSTATE_FLASHED;
+    if (pstate_pred.tfstate & no_weap_mask || CVARF(r_drawviewmodel) == 0) {
         pweap_ent.modelindex = 0;
         return;
     }

--- a/share/defs.h
+++ b/share/defs.h
@@ -249,6 +249,7 @@ enumflags {
     TFSTATE_NO_WEAPON,     // Weapon is disabled and not visible (e.g. detpack)
                            // (Note: We don't use NO_WEAPON for reloading
                            // as it could result in stacked no-weapon states.)
+    TFSTATE_FLASHED,
     TFSTATE_QUICKSLOT,     // QUICKSTOP should change to last weapon.
     TFSTATE_INFECTED,      // set when player is infected by the bioweapon
     TFSTATE_INVINCIBLE,    // Player has permanent Invincibility (Usually by GoalItem)

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -64,6 +64,37 @@ struct predict_tf_state {
 
 float (string ps_short, string ps_setting, string ps_default) CF_GetSetting;
 
+struct fo_predsnd {
+    int id;
+    string sound;
+};
+
+enum {
+    SND_AXE,
+    SND_SG,
+    SND_SSG,
+    SND_RL,
+    SND_GREN,
+    SND_NAIL,
+    SND_SNAIL,
+    SND_FLAMETHROWER,
+    SND_RAILGUN,
+    SND_TRANQ,
+};
+
+fo_predsnd snd_types[] = {
+    { SND_AXE, "ax1.wav" },
+    { SND_SG, "guncock.wav" },
+    { SND_SSG, "shotgn2.wav" },
+    { SND_RL, "sgun1.wav" },
+    { SND_GREN, "grenade.wav" },
+    { SND_NAIL, "rocket1i.wav" },
+    { SND_SNAIL, "spike2.wav" },
+    { SND_FLAMETHROWER, "flmfire2.wav" },
+    { SND_RAILGUN, "railgun.wav" },
+    { SND_TRANQ, "dartgun.wav" },
+};
+
 enum {
     FPP_ROCKET,
     FPP_GRENADE,
@@ -80,6 +111,7 @@ struct fo_projectile {
     float speed;
     string model;
     string trail;
+    int snd;
 
     // Automatically initialized below this line.
     float modelindex;
@@ -87,23 +119,38 @@ struct fo_projectile {
 };
 
 fo_projectile fpp_types[] = {
-    { FPP_ROCKET,     PC_SOLDIER_ROCKET_SPEED, "progs/missile.mdl", "" },
-    { FPP_GRENADE,       600, "progs/grenade.mdl", "t_grenade" },
-    { FPP_INCENDIARY,         800, "progs/lavaball.mdl", "t_lavaball" },
-    { FPP_NAIL,              1500, "progs/spike.mdl", "tr_spike" },
-    { FPP_SUPER_NAIL,        1500, "progs/s_spike.mdl", "tr_spike" },
-    { FPP_FLAMETHROWER,       600, "progs/s_explod.spr", "explodesprite" },
-    { FPP_TRANQ,       PC_SPY_TRANQSPEED, "progs/spike.mdl", "tr_spike" },
-    { FPP_RAILGUN,     PC_ENGINEER_RAILSPEED, "progs/e_spike1.mdl", "te_railtrail" },
+    { FPP_ROCKET,     PC_SOLDIER_ROCKET_SPEED, "missile.mdl", "", SND_RL },
+    { FPP_GRENADE,       600, "grenade.mdl", "t_grenade", SND_GREN },
+    { FPP_INCENDIARY,         800, "lavaball.mdl", "t_lavaball", SND_RL },
+    { FPP_NAIL,              1500, "spike.mdl", "tr_spike", SND_NAIL },
+    { FPP_SUPER_NAIL,        1500, "s_spike.mdl", "tr_spike", SND_SNAIL },
+    { FPP_FLAMETHROWER,       600, "s_explod.spr", "explodesprite", SND_FLAMETHROWER },
+    { FPP_TRANQ,       PC_SPY_TRANQSPEED, "spike.mdl", "tr_spike", SND_TRANQ },
+    { FPP_RAILGUN,     PC_ENGINEER_RAILSPEED, "e_spike1.mdl", "te_railtrail", SND_RAILGUN },
 };
 
+
 void InitFppProjectiles() {
-    for (float i = 0; i < fpp_types.length; i++) {
+    float i;
+    static int once;
+    ASSERTD_EQ(once, 0);
+    once = 1;
+
+    for (i = 0; i < fpp_types.length; i++) {
         fo_projectile* desc = &fpp_types[i];
         ASSERTD_EQ(i, desc->id);
+        desc->model = strcat("progs/", desc->model);
         desc->modelindex = getmodelindex(desc->model);
         if (desc->trail != "")
             desc->trailindex = particleeffectnum(strcat("fo-particles.",desc->trail));
+    }
+
+    for (i = 0; i < snd_types.length; i++) {
+        fo_predsnd* snd = &snd_types[i];
+
+        ASSERTD_EQ(i, snd->id);
+        snd->sound = strcat("weapons/", snd->sound);
+        precache_sound(snd->sound);
     }
 }
 
@@ -425,6 +472,24 @@ void WeaponPred_DoServerClientThink() {
 
         self->client_time = held_client_time;
     }
+}
+
+void FO_Sound(entity e, float chan, string samp, float vol, float atten);
+
+void Pred_Sound(float snd) {
+    entity target = self;
+    string wav = snd_types[snd].sound;
+
+    if (infokeyf(self, "fo_wpp_status") & CSQC_WEAP_PRED == 1) {
+        target = self.predict_entity;
+        setorigin(target, self.origin);
+    }
+
+    FO_Sound(target, CHAN_WEAPON, wav, 1, ATTN_NORM);
+}
+
+void PredProj_Sound(float proj_type) {
+    Pred_Sound(fpp_types[proj_type].snd);
 }
 
 void PredProj_Add(entity mis) {

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -2019,6 +2019,7 @@ void (float all_dimensions) SetDimensions = {
     if (all_dimensions)
     {
         self.dimension_seen = DMN_NOFLASH;
+        self.tfstate &= ~TFSTATE_FLASHED;
 
         switch (self.team_no)
         {

--- a/ssqc/engineer.qc
+++ b/ssqc/engineer.qc
@@ -81,6 +81,8 @@ void () LaserBolt_Touch = {
 void () W_FireRailgun = {
     local vector vec, org;
 
+    Pred_Sound(SND_RAILGUN);
+
     self.ammo_nails = self.ammo_nails - 1;
 
     makevectors(self.v_angle);

--- a/ssqc/pyro.qc
+++ b/ssqc/pyro.qc
@@ -548,7 +548,7 @@ void () W_FireFlame = {
         return;
     }
     self.ammo_cells = self.ammo_cells - 1;
-    FO_Sound(self, CHAN_AUTO, "weapons/flmfire2.wav", 1, ATTN_NORM);
+    Pred_Sound(SND_FLAMETHROWER);
     flame = spawn();
     flame.owner = self;
     flame.movetype = MOVETYPE_FLYMISSILE;
@@ -677,7 +677,7 @@ void () W_FireIncendiaryCannon = {
         return;
     }
     self.ammo_rockets = self.ammo_rockets - 3;
-    FO_Sound(self, CHAN_WEAPON, "weapons/sgun1.wav", 1, ATTN_NORM);
+    Pred_Sound(SND_RL);
     KickPlayer(-3, self);
     newmis = spawn();
     newmis.owner = self;

--- a/ssqc/scout.qc
+++ b/ssqc/scout.qc
@@ -205,13 +205,13 @@ void FO_FlashTimer()
 
 void SetFlashDimension(entity te)
 {
-    FO_FlashDimension = ((FO_FlashDimension + 1) == 8) ? DMN_FLASH : FO_FlashDimension + 1;
+    FO_FlashDimension = ((FO_FlashDimension - DMN_FLASH + 1) % 7) + DMN_FLASH;
     
     float playerdimension = 1<<FO_FlashDimension;
 
-    // i hate bitflags and i'm bad so this is probably wrong
-    te.dimension_see = DMN_FLASH | playerdimension;
+    te.dimension_see =  playerdimension | DMN_FLASH;
     te.dimension_seen = playerdimension | DMN_NOFLASH;
+    te.tfstate |= TFSTATE_FLASHED;
 }
 
 void FO_FlashExplode()

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -787,7 +787,7 @@ void (float shotcount, vector dir, vector spread) FireBullets = {
 void () W_FireShotgun = {
     local vector dir;
 
-    FO_Sound(self, CHAN_WEAPON, "weapons/guncock.wav", 1, ATTN_NORM);
+    Pred_Sound(SND_SG);
 
     KickPlayer(-2, self);
     self.ammo_shells = self.ammo_shells - 1;
@@ -803,7 +803,7 @@ void () W_FireSuperShotgun = {
         W_FireShotgun();
         return;
     }
-    FO_Sound(self, CHAN_WEAPON, "weapons/shotgn2.wav", 1, ATTN_NORM);
+    Pred_Sound(SND_SSG);
 
     KickPlayer(-4, self);
     self.ammo_shells = self.ammo_shells - 2;
@@ -1082,7 +1082,6 @@ void () T_MissileTouch = {
 
 void () W_FireRocket = {
     self.ammo_rockets = self.ammo_rockets - 1;
-    FO_Sound(self, CHAN_WEAPON, "weapons/sgun1.wav", 1, ATTN_NORM);
     KickPlayer(-2, self);
 
     newmis = spawn();
@@ -1107,6 +1106,7 @@ void () W_FireRocket = {
     setsize(newmis, '0 0 0', '0 0 0');
     setorigin(newmis, self.origin + v_forward * 8 + '0 0 16');
 
+    PredProj_Sound(FPP_ROCKET);
     PredProj_Add(newmis);
     if (project_weapons) {
         AL_ProjectProjectile(newmis);
@@ -1285,7 +1285,7 @@ void () ExplodeOldestPipebomb = {
 
 void () W_FireGrenade = {
     self.ammo_rockets = self.ammo_rockets - 1;
-    FO_Sound(self, CHAN_WEAPON, "weapons/grenade.wav", 1, 1);
+    Pred_Sound(SND_GREN);
     KickPlayer(-2, self);
     newmis = spawn();
     newmis.voided = 0;
@@ -1365,7 +1365,7 @@ void () W_FireSuperSpikes = {
     local vector dir;
     FO_WeapInfo* wi = FO_GetWeapInfo(WEAP_SUPER_NAILGUN);
 
-    FO_Sound(self, CHAN_WEAPON, "weapons/spike2.wav", 1, ATTN_NORM);
+    PredProj_Sound(FPP_SUPER_NAIL);
 
     self.ammo_nails -= wi->ammo_per_shot;
 
@@ -1397,7 +1397,7 @@ void (float ox) W_FireSpikes = {
         return;
     }
 
-    FO_Sound(self, CHAN_WEAPON, "weapons/rocket1i.wav", 1, ATTN_NORM);
+    PredProj_Sound(FPP_NAIL);
     self.ammo_nails -= wi->ammo_per_shot;
 
     dir = aim(self, 1000);
@@ -1662,19 +1662,19 @@ void () W_Attack = {
     self.show_hostile = time + 1;
 
     if (ws.weapon == WEAP_AXE) {
-        FO_Sound(self, CHAN_WEAPON, "weapons/ax1.wav", 1, ATTN_NORM);
+        Pred_Sound(SND_AXE);
         if (shared_prng(self) < 0.5)
             player_axe1();
         else
             player_axeb1();
     } else if (ws.weapon == WEAP_KNIFE) {
-        FO_Sound(self, CHAN_WEAPON, "weapons/ax1.wav", 1, ATTN_NORM);
+        Pred_Sound(SND_AXE);
         if (shared_prng(self) < 0.5)
             player_knife1();
         else
             player_knifeb1();
     } else if (ws.weapon == WEAP_SPANNER) {
-        FO_Sound(self, CHAN_WEAPON, "weapons/ax1.wav", 1, ATTN_NORM);
+        Pred_Sound(SND_AXE);
         player_spanner1();
     } else if (ws.weapon == WEAP_SHOTGUN) {
         player_shot1();
@@ -1744,17 +1744,15 @@ void () W_Attack = {
             self.antispam_incendiary_cannon = time + 3;
         }
     } else if (ws.weapon == WEAP_MEDIKIT) {
-        FO_Sound(self, CHAN_WEAPON, "weapons/ax1.wav", 1, ATTN_NORM);
+        Pred_Sound(SND_AXE);
         if (shared_prng(self) < 0.5)
             player_medikit1();
         else
             player_medikitb1();
     } else if (ws.weapon == WEAP_TRANQ) {
-        FO_Sound(self, CHAN_WEAPON, "weapons/dartgun.wav", 1, ATTN_NORM);
         player_shot1();
         W_FireTranq();
     } else if (ws.weapon == WEAP_RAILGUN) {
-        FO_Sound(self, CHAN_WEAPON, "weapons/railgun.wav", 1, ATTN_NORM);
         player_shot1();
         W_FireRailgun();
     }

--- a/ssqc/world.qc
+++ b/ssqc/world.qc
@@ -374,7 +374,6 @@ void () worldspawn = {
 
     }
 
-    InitFppProjectiles();
     dimension_send = DMN_NOFLASH;
 
     settings_to_track = memalloc(sizeof(*settings_to_track)*settings_to_track_list.length);


### PR DESCRIPTION
Add client-side sound for all predicted weapons, match up with animations, and conditionally filter server sounds whenever prediction occurred.  Also, substitute sound later when we realize prediction was missed.