### PR TITLE
HUD fixes

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -399,7 +399,12 @@ float TeamScore[4];
 enum PanelID:float {
     HUDP_INVALID = 0,  // Reserve 0 so we can recognize an uninit menu
     HUDP_FIRST = 100,
-    HUDP_CLIPSIZE = HUDP_FIRST,
+    HUDP_TEAMSCORE = HUDP_FIRST,  // We put this first so that we open to below.
+    HUDP_MAP_MENU,    // We put these up front so that they are
+    HUDP_SHOWSCORES,  // rendered under other elements when editing
+    HUDP_MENU,
+    HUDP_MENU_HINT,
+    HUDP_CLIPSIZE,
     HUDP_FRAGSTREAK,
     HUDP_CAPS,
     HUDP_GREN1,
@@ -408,14 +413,9 @@ enum PanelID:float {
     HUDP_IDENTIFY,
     HUDP_FLAGINFO,
     HUDP_GRENTIMER,
-    HUDP_MENU,
     HUDP_MOTD,
-    HUDP_MENU_HINT,
     HUDP_GAME_MODE,
     HUDP_READY,
-    HUDP_SHOWSCORES,
-    HUDP_TEAMSCORE,
-    HUDP_MAP_MENU,
     HUDP_HEALTH,
     HUDP_FACE,
     HUDP_AMMO,
@@ -490,6 +490,7 @@ typedef struct {
     float TextScale;
     float Display;
     float Orientation;
+    float System;  // System panel display is not user managed (e.g. vote menu)
     void(float display, string text) drawPanel;
     string() getValue;
     float Style;
@@ -603,6 +604,11 @@ void HRC_Invalidate(PanelID panel) {
                 hud_render_cache.free_cache[i] = hud_render_cache.free_cache[j];
                 hud_render_cache.free_cache[j] = tmp;
             }
+}
+
+void HRC_InvalidateAll() {
+    hud_render_cache.draw_count = 0;
+    hud_render_cache.free_count = 0;
 }
 
 void HRC_SetActive(PanelID panel) {

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -269,6 +269,7 @@ void() CSQC_Parse_Event = {
             if(rtr) {
                 round_time_remaining = time + rtr;
             }
+            FO_Hud_ShowPanel(HUDP_MOTD);
             break;
         case MSG_TEAM_SCORES:
             TeamScore[0] = readfloat();

--- a/csqc/hud.qc
+++ b/csqc/hud.qc
@@ -22,27 +22,6 @@ void FO_Hud_Editor_LoadDefaultSettings()
     // check struct, put defaults in
     float yoffset = height - 64;
 
-    // TODO - maybe implement these to allow for pivoting of items
-/*
-    vector pos, fill;
-    float scale, display, Orientation;
-    pos = [width - 8 - FO_HUD_CLIPSIZE_PANEL_X, height - 8 - FO_HUD_CLIPSIZE_PANEL_Y];
-    scale = 1;
-    display = 1;
-    Orientation = FO_HUD_INSERT_BEFORE;
-    fill = [FO_HUD_CLIPSIZE_PANEL_X, FO_HUD_CLIPSIZE_PANEL_Y];
-    
-    for(float i = 0; i < Hud_Panels.length; i++) {
-        pos = [pos_x, pos_y - 2 - 24];
-        getHudPanel(i)->Position = pos;
-        //getHudPanel(i)->FillSize = fillSize;
-        getHudPanel(i)->Scale = scale;
-        getHudPanel(i)->Display = display;
-        getHudPanel(i)->Orientation = Orientation;
-        //pnl.Name = name;
-    }
-*/
-
     //Default menus, id, ready and MOTD to centre of the screen
     getHudPanel(HUDP_GAME_MODE)->Position = [width - getHudPanel(HUDP_GAME_MODE)->FillSize.x, 30];
     getHudPanel(HUDP_GAME_MODE)->Orientation = FO_HUD_INSERT_AFTER;
@@ -70,6 +49,7 @@ void FO_Hud_Editor_LoadDefaultSettings()
     getHudPanel(HUDP_TEAMSCORE)->Position = [(width - getHudPanel(HUDP_TEAMSCORE)->FillSize.x), 0];
     getHudPanel(HUDP_MAP_MENU)->Position = [(width / 2) - (getHudPanel(HUDP_MAP_MENU)->FillSize.x / 2), 30];
     getHudPanel(HUDP_MAP_MENU)->Scale = 1.00;
+    getHudPanel(HUDP_MAP_MENU)->Display = 0;
 }
 
 void FO_Hud_Editor_List_Panels() = {
@@ -198,7 +178,7 @@ void FO_Hud_Editor_Set_Panel_Setting(string panel_name, string setting, string v
             panel.TextScale = stof(value);
             break;
         case "show":
-            panel.Display = stof(value);
+            FO_Hud_SetDisplay(panel->id, stof(value));
             break;
         case "orientation":
             panel.Orientation = stof(value);
@@ -273,20 +253,15 @@ void() Hud_DrawMapMenuPanel = {
     local vector fillsize = panel.FillSize * panel.Scale;
     local float alpha = fo_hud_editor?0.2:0.9;
     local vector position = getPanelPosition(panel);
-    if(panel.Display) {
+    if(panel.Display)
         setcursormode(TRUE);
-    }
     if (hud_panel(panel->id, position, fillsize, alpha, panel.Display)) {
         // click event
-        if (fo_hud_editor) {
-            
-        }
     }
 
-    if(fo_hud_editor) {
+    if (fo_hud_editor)
         return;
-    }
-    
+
     local vector bgcolour = MENU_BG_DARK, textcolour = MENU_TEXT_1;
     local float textscale = 1, padding = 4, cnt = 0;
     local float titlesize = 12;
@@ -304,7 +279,7 @@ void() Hud_DrawMapMenuPanel = {
 
     local vector listviewsize = [listitemsize.x, fillsize.y - padding * 3 - listitemsize.y];
     local float visiblelistitems = floor(listviewsize.y / listitemsize.y);
- 
+
      //Window title
     sui_push_frame(position + [padding,padding], [fillsize.x - padding * 2, titlesize]);
     sui_set_align([SUI_ALIGN_CENTER, SUI_ALIGN_CENTER]);
@@ -625,12 +600,10 @@ void Hud_DrawFlagStatusBar()
             float bigfontvoffset = sizey / 2 - bigfont / 2; //Center text against the icon
             if (FlagInfoLines[i].state == FLAGINFO_CARRIED) 
             {
-                // HRC_drawstring([pos_x + sizex, pos_y + bigfontvoffset + sizey * i, 0], FlagInfoLines[i].carrier, [bigfont,bigfont], '1 0 0', 1, 0);
                 HRC_drawstring([GetTextAlignOffset(pos_x,sizex,sizex,FlagInfoLines[i].carrier,bigfont,getHudPanel(HUDP_FLAGINFO)->Orientation), pos_y + bigfontvoffset + sizey * i, 0], FlagInfoLines[i].carrier, [bigfont,bigfont], '1 0 0', 1, 0);
             } 
             else if (FlagInfoLines[i].state == FLAGINFO_DROPPED && FlagInfoLines[i].locname) 
             {
-                // HRC_drawstring([pos_x + sizex, pos_y + bigfontvoffset + sizey * i, 0], FlagInfoLines[i].locname, [bigfont,bigfont], '1 1 1', 1, 0);
                 HRC_drawstring([GetTextAlignOffset(pos_x,sizex,sizex,FlagInfoLines[i].locname,bigfont,getHudPanel(HUDP_FLAGINFO)->Orientation), pos_y + bigfontvoffset + sizey * i, 0], FlagInfoLines[i].locname, [bigfont,bigfont], '1 1 1', 1, 0);
             }
 
@@ -665,7 +638,7 @@ void Hud_DrawHudOptionsPanelSelector() {
     vector size = getHudPanel(HUDP_OPTIONS)->FillSize * getHudPanel(HUDP_OPTIONS)->Scale; //for simplicity, use the same size as options panel
     float textsize = 8 * (getHudPanel(HUDP_OPTIONS)->TextScale ? getHudPanel(HUDP_OPTIONS)->TextScale : getHudPanel(HUDP_OPTIONS)->Scale);
     if((pos.x + (size.x * 2)) < ScreenSize.x) {
-        //If there's room on the screen, HRC_draw to the right of options panel
+        //If there's room on the screen, draw to the right of options panel
         pos.x = pos.x + size.x;
     } else {
         pos.x = pos.x - size.x;
@@ -677,7 +650,7 @@ void Hud_DrawHudOptionsPanelSelector() {
     }
 
     float numlines = rint(size.y / (textsize + 2));
-    //Need to HRC_draw scrollbar?
+    // Need to draw scrollbar?
     if((Hud_Panels.length * (textsize + 2)) > size.y) {
         //Scrollbar buttons
         if(hud_button(HUDB_OPTION_SCROLLUP, pos + [size.x - textsize - 2,2], [textsize, textsize], "^")) {
@@ -722,30 +695,31 @@ void Hud_DrawHudOptionsPanel(float display, string text) {
         getHudPanel(HUDP_OPTIONS)->Status = !getHudPanel(HUDP_OPTIONS)->Status;
     }
 
-    if (selectedPanel != panel) {
-        float fscale = selectedPanel.Scale;
+    if (selectedPanel != panel /* Don't allow editing the options panel itself */) {
+        float fscale = selectedPanel->Scale;
         HRC_drawstring(pos + [4,12], strcat("Scale: ",ftos(rint(fscale * 100)), "%"), [8,8], MENU_SELECTED, 1, 0);
         hud_slider(HUDE_OPTION_SCALE_SLIDER, pos + [8,24], [136,8], [0.2,5.0,24], fscale);
-        if(fscale != selectedPanel.Scale)
-            getHudPanel(Editor_SelectedPanel_Index)->Scale = fscale;
+        if(fscale != selectedPanel->Scale)
+            selectedPanel->Scale = fscale;
 
-        float ftscale = selectedPanel.TextScale;
-        HRC_drawstring(pos + [4,34], strcat("Text Scale: ",ftos(rint(ftscale * 100)), "%"), [8,8], MENU_SELECTED, 1, 0);
+        float ftscale = selectedPanel->TextScale;
+        string scales = ftscale ? strcat(ftos(rint(ftscale * 100)), "%") : "Auto";
+        HRC_drawstring(pos + [4,34], strcat("Text Scale: ",scales), [8,8], MENU_SELECTED, 1, 0);
         hud_slider(HUDE_OPTION_TEXTSCALE_SLIDER, pos + [8,44], [136,8], [0,5.0,25], ftscale);
-        if(ftscale != selectedPanel.TextScale)
+        if(ftscale != selectedPanel->TextScale)
             getHudPanel(Editor_SelectedPanel_Index)->TextScale = ftscale;
-        float ftextalign = selectedPanel.Orientation;
-        //drawstring(pos + [4,54], strcat("Text Pos: ", selectedPanel.Orientation ? "Left" : "Right"), [8,8], MENU_SELECTED, 1, 0);
+        float ftextalign = selectedPanel->Orientation;
+        //drawstring(pos + [4,54], strcat("Text Pos: ", selectedPanel->Orientation ? "Left" : "Right"), [8,8], MENU_SELECTED, 1, 0);
         HRC_drawstring(pos + [4,60], "Text Pos: ", [8,8], MENU_SELECTED, 1, 0);
-        if(hud_button(HUDE_OPTION_TEXTALIGN_TOGGLE, pos + [size.x - 6 - 56,56], [56, 16], HUD_ALIGN[selectedPanel.Orientation])) {
-            getHudPanel(Editor_SelectedPanel_Index)->Orientation = (selectedPanel.Orientation + 1) % 3;
+        if(hud_button(HUDE_OPTION_TEXTALIGN_TOGGLE, pos + [size.x - 6 - 56,56], [56, 16], HUD_ALIGN[selectedPanel->Orientation])) {
+            selectedPanel->Orientation = (selectedPanel->Orientation + 1) % 3;
         }
         //hud_slider("hud_option_textalign_scroll", pos + [8,64], [32,8], [0,1,1], ftextalign);
-        //if(ftextalign != selectedPanel.Orientation) {
+        //if(ftextalign != selectedPanel->Orientation) {
         //    getHudPanel(Editor_SelectedPanel_Index)->Orientation = ftextalign;
         //}    
-        if(hud_button(HUDE_OPTION_SHOWHIDE_TOGGLE, pos + [4,74], [140, 16], selectedPanel.Display ? "Hide Panel" : "Show Panel")) {
-            getHudPanel(Editor_SelectedPanel_Index)->Display = !selectedPanel.Display;
+        if(!selectedPanel->System && hud_button(HUDE_OPTION_SHOWHIDE_TOGGLE, pos + [4,74], [140, 16], selectedPanel->Display ? "Hide Panel" : "Show Panel")) {
+            FO_Hud_SetDisplay(selectedPanel->id, !selectedPanel->Display);
         }
     }
     HRC_drawstring(pos + [4,96],"Position: ", [8,8], MENU_SELECTED, 1, 0);
@@ -754,9 +728,9 @@ void Hud_DrawHudOptionsPanel(float display, string text) {
 
     local float snap = 0;
     local string ssnap;
-    if(getHudPanel(Editor_SelectedPanel_Index)->Snap & 2) {
+    if(selectedPanel->Snap & 2) {
         snap = 1;
-    } else if(getHudPanel(Editor_SelectedPanel_Index)->Snap & 4) {
+    } else if(selectedPanel->Snap & 4) {
         snap = 2;
     } else {
         snap = 0;
@@ -783,9 +757,10 @@ void Hud_DrawHudOptionsPanel(float display, string text) {
         getHudPanel(Editor_SelectedPanel_Index)->Snap += pow(2,(snap + 3));
     }
     
-    if(hud_button(HUDE_OPTION_SHOWALL_TOGGLE, pos + [4,162], [140, 16], getHudPanel(HUDP_OPTIONS)->Style ? "Show All" : "Hide Disabled")) {
+    if(hud_button(HUDE_OPTION_SHOWALL_TOGGLE, pos + [4,162], [140, 16], getHudPanel(HUDP_OPTIONS)->Style ? "Show All" : "Show HUD Only")) {
         getHudPanel(HUDP_OPTIONS)->Style = !getHudPanel(HUDP_OPTIONS)->Style;
     }
+    FO_Hud_ShowPanel(HUDP_OPTIONS);
 
     if(getHudPanel(HUDP_OPTIONS)->Status) {
         Hud_DrawHudOptionsPanelSelector();

--- a/csqc/hud_helpers.qc
+++ b/csqc/hud_helpers.qc
@@ -1,4 +1,5 @@
 void Hud_WriteCfg(string path);
+void FO_Hud_InitSystemPanels();
 
 void FO_Hud_Editor()
 {
@@ -7,11 +8,14 @@ void FO_Hud_Editor()
         fo_hud_editor = FALSE;
         setcursormode(FALSE);
 
+        FO_Hud_InitSystemPanels();
         Hud_WriteCfg(FO_HUD_CONFIG_PATH);
     }
     else
     {
         fo_hud_editor = TRUE;
+        FO_Hud_InitSystemPanels();
+        FO_Hud_ShowPanel(HUDP_OPTIONS);
         setcursormode(TRUE);
     }
 }
@@ -83,8 +87,6 @@ float(PanelID id, vector pos, vector size, float alpha, float enabled) hud_panel
         {
             alpha = 0.6;
             basecolor = MENU_BG + MENU_HIGHLIGHT * 0.1;
-            //FO_Hud_Panel hoverpanel = GetPanelById(id);
-            //HRC_drawstring([Mouse.x, Mouse.y], hoverpanel.Name, '8 8', '1 0 0', 1, 0);
         }
         
         if (sui_is_held(id))
@@ -109,7 +111,7 @@ float(PanelID id, vector pos, vector size, float alpha, float enabled) hud_panel
     return sui_is_clicked(id);
 };
 
-// this HRC_draws backwards, haven't bothered to change as we don't use it
+// this draws backwards, haven't bothered to change as we don't use it
 void Hud_DrawLargeValue(vector pos, float value, float threshhold, float size)
 {
     float c;
@@ -231,6 +233,44 @@ string GetPanelString(string line, FO_Hud_Panel* panel)
     return line;
 }
 
+void FO_Hud_HidePanel(PanelID id) {
+    getHudPanel(id)->Display = FALSE;
+    HRC_Invalidate(id);
+}
+
+void FO_Hud_ShowPanel(PanelID id) {
+    getHudPanel(id)->Display = TRUE;
+}
+
+void FO_Hud_SetDisplay(PanelID id, float display) {
+    if (display)
+        FO_Hud_ShowPanel(id);
+    else
+        FO_Hud_HidePanel(id);
+}
+
+// Hide panels that are used by other systems, e.g. scores or map voting menu,
+// that we don't want bein inadvertently rendered.
+void FO_Hud_InitSystemPanels() {
+    for (float i = HUDP_FIRST; i <= HUDP_LAST; i++) {
+        FO_Hud_Panel* panel = getHudPanel(i);
+        if (panel->System) {
+            switch (panel->id) {
+                case HUDP_MOTD:
+                case HUDP_READY:
+                    FO_Hud_ShowPanel(i);
+                    break;
+
+                case HUDP_MAP_MENU: // Enumerated for readability, not necessity
+                case HUDP_MENU:
+                default:
+                    FO_Hud_HidePanel(i);
+                    break;
+            }
+        }
+    }
+}
+
 float firstrun;
 void FO_Hud_Editor_LoadSettings(string filename)
 {
@@ -304,7 +344,7 @@ void FO_Hud_Editor_LoadSettings(string filename)
                                 panel.TextScale = stof(val);
                                 break;
                             case "display":
-                                panel.Display = stof(val);
+                                FO_Hud_SetDisplay(panel->id, stof(val));
                                 break;
                             case "nodeinsertloc":
                                 panel.Orientation = stof(val);
@@ -335,9 +375,11 @@ void FO_Hud_Editor_LoadSettings(string filename)
     if(getHudPanel(HUDP_MENU)->Position.x + getHudPanel(HUDP_MENU)->FillSize.x > vsize_x) getHudPanel(HUDP_MENU)->Position.x = vsize_x / 2 - getHudPanel(HUDP_MENU)->FillSize.x / 2;
     if(getHudPanel(HUDP_MENU)->Position.y + getHudPanel(HUDP_MENU)->FillSize.y > vsize_y) getHudPanel(HUDP_MENU)->Position.y = 64;
 
-
+    FO_Hud_InitSystemPanels();
 }
 
+
+// Inherits active render cache id
 void GetNewPanel(vector pos, vector fillSize, float scale, float display, float orientation, string name)
 {
     FO_Hud_Panel pnl;
@@ -352,7 +394,7 @@ void GetNewPanel(vector pos, vector fillSize, float scale, float display, float 
     NewPanel = pnl;
 }
 
-// HRC_draws value string using lmps
+// draws value string using lmps
 void Hud_DrawPanelLMP(FO_Hud_Panel* panel, string val, string icon, float icon_alpha)
 {
     if (!panel.Display && !fo_hud_editor)
@@ -372,9 +414,7 @@ void Hud_DrawPanelLMP(FO_Hud_Panel* panel, string val, string icon, float icon_a
         }
     }
 
-    //vector size = FO_Hud_Icon_Size * panel.Scale;
     pos = [pos_x + 2, pos_y + 2, 0];
-    //HRC_drawpic(pos, icon, size, '1 1 1', 1, 0);
 
     HRC_drawpic(pos, icon, scaledFillSize, '1 1 1', icon_alpha, 0);
 
@@ -421,7 +461,6 @@ void Hud_DrawLMPThreshold(FO_Hud_Panel* panel, string val, float threshold)
     pos = [pos_x + 2, pos_y + 2, 0];
 /*
     vector size = FO_Hud_Icon_Size * panel.Scale;
-    //HRC_drawpic(pos, icon, size, '1 1 1', 1, 0);
 
 
     pos = [pos_x + offset, pos_y, 0];

--- a/csqc/menu.qc
+++ b/csqc/menu.qc
@@ -12,6 +12,7 @@ void (float force) FO_Menu_Spy_Team;
 void (float force) FO_Menu_Class;
 void (float force) showVoteMenu;
 void FO_Menu_Admin_Players(float force, float type, float page);
+void FO_Hud_SetDisplay(PanelID id, float display);
 
 typedef struct {
     string shortcut;    //key to press. if omitted - mouse only
@@ -663,8 +664,6 @@ vector fo_menu_draw(fo_menu * menu) = {
         return position;
     }
 
-    getHudPanel(HUDP_MAP_MENU).Display = FALSE;
-
     thisorigin = (vector)getentity(player_localentnum, GE_ORIGIN);
     setcursormode(menu.flags & FO_MENU_FLAG_USE_MOUSE);
     
@@ -1308,7 +1307,7 @@ void (float show) showVoteMenu = {
         Menu_Cancel();
     }
     setcursormode(show);
-    getHudPanel(HUDP_MAP_MENU)->Display = show;
+    FO_Hud_SetDisplay(HUDP_MAP_MENU, show);
     if(show) {
         CurrentMenu = &FO_MENU_VOTE;
     }

--- a/csqc/status.qc
+++ b/csqc/status.qc
@@ -5,6 +5,8 @@ vector (FO_Hud_Panel* panel) getPanelFillSize;
 void Hud_DrawPanelLMP(FO_Hud_Panel*, string, string, float);
 void Hud_DrawLMPThreshold(FO_Hud_Panel*, string, float);
 FO_Hud_Panel* getHudPanel(PanelID);
+void FO_Hud_HidePanel(PanelID id);
+void FO_Hud_ShowPanel(PanelID id);
 
 void(PanelID ignored, string text) drawClipSize = {
     if (SBAR.ClipSize != "" || fo_hud_editor)
@@ -391,6 +393,10 @@ void(PanelID panelid, string text) drawTextPanel = {
 void(PanelID panelid, string text) drawMOTDPanel = {
     FO_Hud_Panel* panel = getHudPanel(panelid);
     
+    // No need to render MOTD once expired.
+    if (time > motd_expiry && panel->Display)
+        FO_Hud_HidePanel(panel->id);
+
     //vector position = getPosition(id);
     //vector size = getFillSize(id);
     vector position = getPanelPosition(panel); //panel.Position;
@@ -410,6 +416,8 @@ void(PanelID panelid, string text) drawMOTDPanel = {
             // click event
         }
     }
+
+
     if((showingscores || !panel.Display) && !fo_hud_editor) {
         return;
     }
@@ -1052,8 +1060,7 @@ void(PanelID panelid, string text) drawShowScoresPanel = {
 
 void (float show) FO_Show_Scores = {
     showingscores = show;
-    FO_Hud_Panel* panel = getHudPanel(HUDP_SHOWSCORES);
-    if(panel && &panel != &NullPanel) panel.Display = show;
+    getHudPanel(HUDP_SHOWSCORES)->Display = show;
 };
 
 var FO_Hud_Panel Hud_Panels[] = {
@@ -1062,53 +1069,53 @@ var FO_Hud_Panel Hud_Panels[] = {
 //  string getValue(),
 //  Style, Snap, Status
 
-    {HUDP_CLIPSIZE, "clipsize", FO_HUD_CLIPSIZE_NAME,     '464 455', '26 26',  0.75,0,1,0, drawClipSize, { return WP_GetClip(); }},
-    {HUDP_FRAGSTREAK, "fragstreak", FO_HUD_FRAGSTREAK_NAME, '10 50',   '26 26',  1,0,1,0, drawFragStreakPanel, {return ftos(SBAR.FragStreak);}},
-    {HUDP_CAPS, "caps", FO_HUD_CAPS_NAME,             '10 80',   '26 26',  1,0,1,0, drawCapsPanel, {return ftos(SBAR.Caps);}},
-    {HUDP_GREN1, "gren1", FO_HUD_GREN1_NAME,           '10 110',  '26 26',  1,0,1,0, drawGren1Panel, {return ftos(getstatf(STAT_NO_GREN1));}},
-    {HUDP_GREN2, "gren2", FO_HUD_GREN2_NAME,           '10 140',  '26 26',  1,0,1,0, drawGren2Panel, {return ftos(getstatf(STAT_NO_GREN2));}},
-    {HUDP_SPECIAL, "playerclass", FO_HUD_SPECIAL_NAME,   '10 170',  '50 26',  1,0,1,0, drawSpecial, {return ftos(SBAR.PlayerClass);}},
-    {HUDP_IDENTIFY, "identify", FO_HUD_IDENTIFY_NAME,     '10 200',  '50 26',  1,0,1,FO_HUD_INSERT_MIDDLE, drawIdentify, {return SBAR.Identify;}},
-    {HUDP_FLAGINFO, "flaginfo", FO_HUD_FLAGINFO_NAME,     '10 230',  '26 260', 1,0,1,0, drawFlagInfo, {return "";}},
-    {HUDP_GRENTIMER, "grentimer", FO_HUD_GRENTIMER_NAME,   '100 110', '26 26',  1,0,1,0, drawGrenTimerPanel, {return "";}},
-    {HUDP_MENU, "menu", "Menu",                       '10 110',  '300 200',1,0,1,0, drawSimplePanel, {return "";}},
-    {HUDP_MOTD, "motd", FO_HUD_MOTD_NAME,             '150 100', '100 24', 1,0,1,0, drawMOTDPanel, {return SBAR.MOTD;}},
-    {HUDP_MENU_HINT, "menuhint", FO_HUD_MENU_HINT_NAME,    '100 300', '300 24', 1,0,1,0, drawTextPanel, {return SBAR.Hint;}},
-    {HUDP_GAME_MODE, "gamemode", FO_HUD_GAME_MODE_NAME,    '100 140', '100 10', 1,0,1,0, drawGameModePanel, {return "";}},
-    {HUDP_READY, "ready", FO_HUD_READY_NAME,           '10 100',  '100 10', 2,0,1,FO_HUD_INSERT_MIDDLE, drawReadyPanel, {return SBAR.Hint;}},
-    {HUDP_SHOWSCORES, "showscores", FO_HUD_SHOWSCORES_NAME, '10 100',  '600 200',1,0,0,FO_HUD_INSERT_MIDDLE, drawShowScoresPanel, {return "";}},
-    {HUDP_TEAMSCORE, "teamscore", FO_HUD_TEAM_SCORE_NAME,  '0 0',     '72 12',  2,0,1,FO_HUD_INSERT_AFTER, drawTeamScorePanel, {return "";}},
-    {HUDP_MAP_MENU, "mapmenu", FO_HUD_MAP_MENU_NAME,      '10 30',   '800 400',1,0,1,FO_HUD_INSERT_MIDDLE, drawMapMenuPanel, {return "";}},
-    {HUDP_HEALTH, "health", FO_HUD_HEALTH_NAME,         '-22 -2',  '72 24',  1,0,1,0, drawHealthArmourTextPanel, {return ftos(getstatf(STAT_HEALTH));}, 0, 34},
-    {HUDP_FACE, "face", FO_HUD_FACE_NAME,             '-70 -2',  '24 24',  1,0,1,0, drawFacePanel, {return "";}, 0, 34},
-    {HUDP_AMMO, "ammo", FO_HUD_AMMO_NAME,             '90 -2',   '72 24',  1,0,1,0, drawAmmoTextPanel, {return ftos(WP_CurrentAmmo());}, 0, 34},
-    {HUDP_AMMOICON, "ammoicon", FO_HUD_AMMO_ICON_NAME ,   '42 -2',   '24 24',  1,0,1,0, drawAmmoPanel, {return "";}, 0, 34},
-    {HUDP_ARMOUR, "armour", FO_HUD_ARMOUR_NAME,         '-134 -2', '72 24',  1,0,1,0, drawHealthArmourTextPanel, {return ftos(getstatf(STAT_ARMOR));}, 0, 34},
-    {HUDP_ARMOURICON, "armouricon", FO_HUD_ARMOUR_ICON_NAME,'-182 -2', '24 24',  1,0,1,0, drawArmourPanel, {return "";}, 0, 34},
-    {HUDP_INVSHELLS, "invshells", FO_HUD_INV_SHELLS_NAME,  '-2 -244', '24 24',  1,1.4,1,0, drawInvShellsPanel, {return ftos(WP_GetAmmo(AMMO_SHELLS));}, 1, 33},
-    {HUDP_INVNAILS, "invnails", FO_HUD_INV_NAILS_NAME,    '-2 -220', '24 24',  1,1.4,1,0, drawInvNailsPanel, {return ftos(WP_GetAmmo(AMMO_NAILS));}, 1, 33},
-    {HUDP_INVROCKETS, "invrockets", FO_HUD_INV_ROCKETS_NAME,'-2 -196', '24 24',  1,1.4,1,0, drawInvRocketsPanel, {return ftos(WP_GetAmmo(AMMO_ROCKETS));}, 1, 33},
-    {HUDP_INVCELLS, "invcells", FO_HUD_INV_CELLS_NAME,    '-2 -172', '24 24',  1,1.4,1,0, drawInvCellsPanel, {return ftos(WP_GetAmmo(AMMO_CELLS));}, 1, 33},
-    {HUDP_GAMECLOCK, "gameclock", "Game Clock",            '0 0'   ,  '108 24', 1,0.8,1,0, drawClockPanel, {return gameClockString();}, 0, 10},
-    {HUDP_QUAD, "quad", "Quad Icon",                  '-200 -30','26 26',  1,1.4,1,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_QUAD)?"textures/wad/sb_quad":"";}, 0, 36},
-    {HUDP_PENT, "pent", "Pentagram Icon",             '-170 -30','26 26',  1,1.4,1,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_INVULNERABILITY)?"textures/wad/sb_invuln":"";}, 0, 36},
-    {HUDP_RING, "ring", "Ring Icon",                  '-140 -30','26 26',  1,1.4,1,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_INVISIBILITY)?"textures/wad/sb_invis":"";}, 0, 36},
-    {HUDP_SUIT, "suit", "Biosuit Icon",               '-110 -30','26 26',  1,1.4,1,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_SUIT)?"textures/wad/sb_suit":"";}, 0, 36},
-    {HUDP_KEY1, "key1", "Silver Key",                 '140 -30', '26 26',  0.6,1.4,1,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_KEY1)?"textures/wad/sb_key1":"";}, 0, 34},
-    {HUDP_KEY2, "key2", "Gold Key",                   '160 -30', '26 26',  0.6,1.4,1,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_KEY2)?"textures/wad/sb_key2":"";}, 0, 34},
-    {HUDP_RUNE1, "rune1", "Earth Rune",                '-200 0',  '26 26',  1,1.4,1,0, drawInvIconPanel, {return (getstatbits(STAT_ITEMS,28,4) & 1)?"textures/wad/sb_sigi1":"";}, 0, 34},
-    {HUDP_RUNE2, "rune2", "Black Rune",                '-170 0',  '26 26',  1,1.4,1,0, drawInvIconPanel, {return (getstatbits(STAT_ITEMS,28,4) & 2)?"textures/wad/sb_sigil2":"";}, 0, 34},
-    {HUDP_RUNE3, "rune3", "Hell Rune",                 '-140 0',  '26 26',  1,1.4,1,0, drawInvIconPanel, {return (getstatbits(STAT_ITEMS,28,4) & 4)?"textures/wad/sb_sigil3":"";}, 0, 34},
-    {HUDP_RUNE4, "rune4", "Elder Rune",                '-110 0',  '26 26',  1,1.4,1,0, drawInvIconPanel, {return (getstatbits(STAT_ITEMS,28,4) & 8)?"textures/wad/sb_sigil4":"";}, 0, 34},
-    {HUDP_GUN2, "gun2", "Shotgun",                    '-4 -170', '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_SHOTGUN);}, 0, 36},
-    {HUDP_GUN3, "gun3", "Super Shotgun",              '-4 -150', '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_SUPER_SHOTGUN);}, 0, 36},
-    {HUDP_GUN4, "gun4", "Nailgun",                    '-4 -130', '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_NAILGUN);}, 0, 36},
-    {HUDP_GUN5, "gun5", "Super Nailgun",              '-4 -110', '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_SUPER_NAILGUN);}, 0, 36},
-    {HUDP_GUN6, "gun6", "Grenade Launcher",           '-4 -90',  '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_GRENADE_LAUNCHER);}, 0, 36},
-    {HUDP_GUN7, "gun7", "Rocket Launcher",            '-4 -70',  '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_ROCKET_LAUNCHER);}, 0, 36},
-    {HUDP_GUN8, "gun8", "Lighning Gun",               '-4 -50',  '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_LIGHTNING);}, 0, 36},
-    {HUDP_SPEED, "speed", "Speed",                     '4 15',    '26 26',  1,1.4,0,0, drawTextPanel, {return CVARF(fo_fte_hud) ? sprintf("%3.1f UPS", speed) : "";}, 0, 4},
-    {HUDP_OPTIONS, "hudoptions", FO_HUD_OPTIONS_NAME,    '10 10',   '150 182',1,   0,1,0, doNothing, {return "";}, 1},
+    {HUDP_TEAMSCORE, "teamscore", FO_HUD_TEAM_SCORE_NAME,  '0 0',     '72 12',  2,0,1,FO_HUD_INSERT_AFTER, 0, drawTeamScorePanel, {return "";}},
+    {HUDP_MAP_MENU, "mapmenu", FO_HUD_MAP_MENU_NAME,      '10 30',   '800 400',1,0,1,FO_HUD_INSERT_MIDDLE, 1, drawMapMenuPanel, {return "";}},
+    {HUDP_SHOWSCORES, "showscores", FO_HUD_SHOWSCORES_NAME, '10 100',  '600 200',1,0,1,FO_HUD_INSERT_MIDDLE, 1, drawShowScoresPanel, {return "";}},
+    {HUDP_MENU, "menu", "Menu",                       '10 110',  '300 200',1,0,1,0,1, drawSimplePanel, {return "";}},
+    {HUDP_MENU_HINT, "menuhint", FO_HUD_MENU_HINT_NAME,    '100 300', '300 24', 1,0,1,0,0, drawTextPanel, {return SBAR.Hint;}},
+    {HUDP_CLIPSIZE, "clipsize", FO_HUD_CLIPSIZE_NAME,     '464 455', '26 26',  0.75,0,1,0,0, drawClipSize, { return WP_GetClip(); }},
+    {HUDP_FRAGSTREAK, "fragstreak", FO_HUD_FRAGSTREAK_NAME, '10 50',   '26 26',  1,0,1,0,0, drawFragStreakPanel, {return ftos(SBAR.FragStreak);}},
+    {HUDP_CAPS, "caps", FO_HUD_CAPS_NAME,             '10 80',   '26 26',  1,0,1,0,0, drawCapsPanel, {return ftos(SBAR.Caps);}},
+    {HUDP_GREN1, "gren1", FO_HUD_GREN1_NAME,           '10 110',  '26 26',  1,0,1,0,0, drawGren1Panel, {return ftos(getstatf(STAT_NO_GREN1));}},
+    {HUDP_GREN2, "gren2", FO_HUD_GREN2_NAME,           '10 140',  '26 26',  1,0,1,0,0, drawGren2Panel, {return ftos(getstatf(STAT_NO_GREN2));}},
+    {HUDP_SPECIAL, "playerclass", FO_HUD_SPECIAL_NAME,   '10 170',  '50 26',  1,0,1,0,0, drawSpecial, {return ftos(SBAR.PlayerClass);}},
+    {HUDP_IDENTIFY, "identify", FO_HUD_IDENTIFY_NAME,     '10 200',  '50 26',  1,0,1,FO_HUD_INSERT_MIDDLE, 0, drawIdentify, {return SBAR.Identify;}},
+    {HUDP_FLAGINFO, "flaginfo", FO_HUD_FLAGINFO_NAME,     '10 230',  '26 260', 1,0,1,0,0, drawFlagInfo, {return "";}},
+    {HUDP_GRENTIMER, "grentimer", FO_HUD_GRENTIMER_NAME,   '100 110', '26 26',  1,0,1,0,0, drawGrenTimerPanel, {return "";}},
+    {HUDP_MOTD, "motd", FO_HUD_MOTD_NAME,             '150 100', '100 24', 1,0,1,0,0, drawMOTDPanel, {return SBAR.MOTD;}},
+    {HUDP_GAME_MODE, "gamemode", FO_HUD_GAME_MODE_NAME,    '100 140', '100 10', 1,0,1,0,0, drawGameModePanel, {return "";}},
+    {HUDP_READY, "ready", FO_HUD_READY_NAME,           '10 100',  '100 10', 2,0,1,FO_HUD_INSERT_MIDDLE, 1, drawReadyPanel, {return SBAR.Hint;}},
+    {HUDP_HEALTH, "health", FO_HUD_HEALTH_NAME,         '-22 -2',  '72 24',  1,0,1,0,0, drawHealthArmourTextPanel, {return ftos(getstatf(STAT_HEALTH));}, 0, 34},
+    {HUDP_FACE, "face", FO_HUD_FACE_NAME,             '-70 -2',  '24 24',  1,0,1,0,0, drawFacePanel, {return "";}, 0, 34},
+    {HUDP_AMMO, "ammo", FO_HUD_AMMO_NAME,             '90 -2',   '72 24',  1,0,1,0,0, drawAmmoTextPanel, {return ftos(WP_CurrentAmmo());}, 0, 34},
+    {HUDP_AMMOICON, "ammoicon", FO_HUD_AMMO_ICON_NAME ,   '42 -2',   '24 24',  1,0,1,0,0, drawAmmoPanel, {return "";}, 0, 34},
+    {HUDP_ARMOUR, "armour", FO_HUD_ARMOUR_NAME,         '-134 -2', '72 24',  1,0,1,0,0, drawHealthArmourTextPanel, {return ftos(getstatf(STAT_ARMOR));}, 0, 34},
+    {HUDP_ARMOURICON, "armouricon", FO_HUD_ARMOUR_ICON_NAME,'-182 -2', '24 24',  1,0,1,0,0, drawArmourPanel, {return "";}, 0, 34},
+    {HUDP_INVSHELLS, "invshells", FO_HUD_INV_SHELLS_NAME,  '-2 -244', '24 24',  1,1.4,1,0,0, drawInvShellsPanel, {return ftos(WP_GetAmmo(AMMO_SHELLS));}, 1, 33},
+    {HUDP_INVNAILS, "invnails", FO_HUD_INV_NAILS_NAME,    '-2 -220', '24 24',  1,1.4,1,0,0, drawInvNailsPanel, {return ftos(WP_GetAmmo(AMMO_NAILS));}, 1, 33},
+    {HUDP_INVROCKETS, "invrockets", FO_HUD_INV_ROCKETS_NAME,'-2 -196', '24 24',  1,1.4,1,0,0, drawInvRocketsPanel, {return ftos(WP_GetAmmo(AMMO_ROCKETS));}, 1, 33},
+    {HUDP_INVCELLS, "invcells", FO_HUD_INV_CELLS_NAME,    '-2 -172', '24 24',  1,1.4,1,0,0, drawInvCellsPanel, {return ftos(WP_GetAmmo(AMMO_CELLS));}, 1, 33},
+    {HUDP_GAMECLOCK, "gameclock", "Game Clock",            '0 0'   ,  '108 24', 1,0.8,1,0,0, drawClockPanel, {return gameClockString();}, 0, 10},
+    {HUDP_QUAD, "quad", "Quad Icon",                  '-200 -30','26 26',  1,1.4,1,0,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_QUAD)?"textures/wad/sb_quad":"";}, 0, 36},
+    {HUDP_PENT, "pent", "Pentagram Icon",             '-170 -30','26 26',  1,1.4,1,0,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_INVULNERABILITY)?"textures/wad/sb_invuln":"";}, 0, 36},
+    {HUDP_RING, "ring", "Ring Icon",                  '-140 -30','26 26',  1,1.4,1,0,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_INVISIBILITY)?"textures/wad/sb_invis":"";}, 0, 36},
+    {HUDP_SUIT, "suit", "Biosuit Icon",               '-110 -30','26 26',  1,1.4,1,0,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_SUIT)?"textures/wad/sb_suit":"";}, 0, 36},
+    {HUDP_KEY1, "key1", "Silver Key",                 '140 -30', '26 26',  0.6,1.4,1,0,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_KEY1)?"textures/wad/sb_key1":"";}, 0, 34},
+    {HUDP_KEY2, "key2", "Gold Key",                   '160 -30', '26 26',  0.6,1.4,1,0,0, drawInvIconPanel, {return (getstatf(STAT_ITEMS) & IT_KEY2)?"textures/wad/sb_key2":"";}, 0, 34},
+    {HUDP_RUNE1, "rune1", "Earth Rune",                '-200 0',  '26 26',  1,1.4,1,0,0, drawInvIconPanel, {return (getstatbits(STAT_ITEMS,28,4) & 1)?"textures/wad/sb_sigi1":"";}, 0, 34},
+    {HUDP_RUNE2, "rune2", "Black Rune",                '-170 0',  '26 26',  1,1.4,1,0,0, drawInvIconPanel, {return (getstatbits(STAT_ITEMS,28,4) & 2)?"textures/wad/sb_sigil2":"";}, 0, 34},
+    {HUDP_RUNE3, "rune3", "Hell Rune",                 '-140 0',  '26 26',  1,1.4,1,0,0, drawInvIconPanel, {return (getstatbits(STAT_ITEMS,28,4) & 4)?"textures/wad/sb_sigil3":"";}, 0, 34},
+    {HUDP_RUNE4, "rune4", "Elder Rune",                '-110 0',  '26 26',  1,1.4,1,0,0, drawInvIconPanel, {return (getstatbits(STAT_ITEMS,28,4) & 8)?"textures/wad/sb_sigil4":"";}, 0, 34},
+    {HUDP_GUN2, "gun2", "Shotgun",                    '-4 -170', '36 24',  0.8,1.4,1,0,0, drawInvIconPanel, {return getGunIcon(IT_SHOTGUN);}, 0, 36},
+    {HUDP_GUN3, "gun3", "Super Shotgun",              '-4 -150', '36 24',  0.8,1.4,1,0,0, drawInvIconPanel, {return getGunIcon(IT_SUPER_SHOTGUN);}, 0, 36},
+    {HUDP_GUN4, "gun4", "Nailgun",                    '-4 -130', '36 24',  0.8,1.4,1,0,0, drawInvIconPanel, {return getGunIcon(IT_NAILGUN);}, 0, 36},
+    {HUDP_GUN5, "gun5", "Super Nailgun",              '-4 -110', '36 24',  0.8,1.4,1,0,0, drawInvIconPanel, {return getGunIcon(IT_SUPER_NAILGUN);}, 0, 36},
+    {HUDP_GUN6, "gun6", "Grenade Launcher",           '-4 -90',  '36 24',  0.8,1.4,1,0,0, drawInvIconPanel, {return getGunIcon(IT_GRENADE_LAUNCHER);}, 0, 36},
+    {HUDP_GUN7, "gun7", "Rocket Launcher",            '-4 -70',  '36 24',  0.8,1.4,1,0,0, drawInvIconPanel, {return getGunIcon(IT_ROCKET_LAUNCHER);}, 0, 36},
+    {HUDP_GUN8, "gun8", "Lighning Gun",               '-4 -50',  '36 24',  0.8,1.4,1,0,0, drawInvIconPanel, {return getGunIcon(IT_LIGHTNING);}, 0, 36},
+    {HUDP_SPEED, "speed", "Speed",                     '4 15',    '26 26',  1,1.4,0,0,0, drawTextPanel, {return CVARF(fo_fte_hud) ? sprintf("%3.1f UPS", speed) : "";}, 0, 4},
+    {HUDP_OPTIONS, "hudoptions", FO_HUD_OPTIONS_NAME,    '10 10',   '150 182',1,   0,1,0,1, doNothing, {return "";}, 1},
 };
 
 inline FO_Hud_Panel* (PanelID panelid) getHudPanel = {


### PR DESCRIPTION
- The HUD editor let you arbitrarily hide/show panels such as the map menu. Clients that had this as shown were getting it stuck in the render cache. Introduce system panels for which this type of edit is not possible and sanitize on load/save.
- Reorder panels so that large panels render on the bottom for editing.
- Dead code cleanup and removal.