### PR TITLE
Fix Escape on Menus

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -361,7 +361,6 @@ typedef struct
 
 MouseStruct Mouse;
 MouseStruct PrevMouse;
-float MouseDown;
 
 typedef struct {
     string filename;
@@ -596,6 +595,8 @@ void HRC_SetActive(PanelID panel) {
     hud_render_cache.active_panel = panel;
 }
 
+FO_Hud_Panel* getHudPanel(PanelID panelid);
+
 // Returns true if HUD should be re-rendered this frame.
 float HRC_NewFrame() {
     // Rate limit even the more complicated enable checks.
@@ -604,7 +605,8 @@ float HRC_NewFrame() {
     /* hud_render_cache.last_update = time; */
 
     if (!CVARF(fo_hud_cache) ||
-        fo_hud_menu_active || fo_hud_editor || showingscores) {
+        fo_hud_menu_active || fo_hud_editor || showingscores ||
+        getHudPanel(HUDP_MAP_MENU)->Display) {
         // Either explicitly disabled, or rendering a more complicated scene
         // like the editor for which we'll just display in place.
         hud_render_cache.enabled = FALSE;

--- a/csqc/hud.qc
+++ b/csqc/hud.qc
@@ -1103,8 +1103,6 @@ struct {
 } incremental_hud;
 
 void Hud_UpdateView(float width, float height, float menushown, float perf_sample) {
-    float hud_update = HRC_NewFrame();
-
     ScreenSize = [width, height, menushown];
     if (HRC_NewFrame()) {
         float hts = perf_start_sample(&hud_timing, perf_sample);

--- a/csqc/input.qc
+++ b/csqc/input.qc
@@ -7,6 +7,7 @@ static float HudInputEscape() {
 
     Menu_Cancel();
     fo_hud_editor = FALSE;
+    printf("menu_close\n");
     return TRUE;
 }
 
@@ -20,19 +21,10 @@ float(float evtype, float scanx, float chary, float devid) CSQC_InputEvent = {
                     return TRUE;
                 break;
             case IE_KEYDOWN:
-                switch (scanx) {
-                    case K_ESCAPE:
-                        if (HudInputEscape())
-                            return TRUE;
-                        break;
-                    case K_MOUSE1:
-                        if(!fo_hud_editor && fo_hud_menu_active &&
-                           !(CurrentMenu.flags & FO_MENU_FLAG_USE_MOUSE))
-                            break;
+                if (scanx == K_ESCAPE || scanx == K_MOUSE1)
+                    return TRUE;
 
-                        return TRUE;
-                }
-                if(fo_hud_menu_active)
+                if (fo_hud_menu_active)
                     return fo_menu_process_input(CurrentMenu, scanx);
                 break;
             case IE_MOUSEDELTA:
@@ -44,6 +36,7 @@ float(float evtype, float scanx, float chary, float devid) CSQC_InputEvent = {
         }
     } else if(getHudPanel(HUDP_MAP_MENU)->Display) {
         sui_input_event(evtype, scanx, chary, devid);
+
         switch (evtype) {
             case IE_MOUSEDELTA:
                 return TRUE;
@@ -52,7 +45,7 @@ float(float evtype, float scanx, float chary, float devid) CSQC_InputEvent = {
                 PrevMouse.y = Mouse.y;
                 Mouse.x = scanx;
                 Mouse.y = chary;
-                if (MouseDown)
+                if (sui_is_held(HUDP_MAP_MENU))
                     Hud_MapMenuPanel_Move(Mouse.x - PrevMouse.x, Mouse.y - PrevMouse.y);
                 return TRUE;
              case IE_KEYDOWN:
@@ -60,7 +53,6 @@ float(float evtype, float scanx, float chary, float devid) CSQC_InputEvent = {
                     case K_ESCAPE:
                         return TRUE;
                     case K_MOUSE1:
-                        MouseDown = TRUE;
                         return TRUE;
                     case K_UPARROW:
                         vote_selected_index--;
@@ -121,9 +113,8 @@ float(float evtype, float scanx, float chary, float devid) CSQC_InputEvent = {
                         showVoteMenu(FALSE);
                         return TRUE;
                     case K_MOUSE1:
-                        MouseDown = FALSE;
                         return TRUE;
-                }       
+                }
             }
     } else {
         switch (evtype)
@@ -132,6 +123,7 @@ float(float evtype, float scanx, float chary, float devid) CSQC_InputEvent = {
                 switch (scanx)
                 {
                     case K_ESCAPE:
+                        printf("menu_open\n");
                         FO_Menu_Game(TRUE);
                         return TRUE;
                 }

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -114,7 +114,6 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     vote_list_offset = 0;
     current_vote = world;
     vote_list_filter = "";
-    MouseDown = 0;
 };
 
 noref void() CSQC_WorldLoaded = {

--- a/csqc/menu.qc
+++ b/csqc/menu.qc
@@ -835,7 +835,7 @@ float fo_menu_process_input(fo_menu * menu, float scan) = {
 }
 
 void Menu_Cancel() = {
-    if(fo_hud_menu_active) {
+    if (fo_hud_menu_active) {
         setcursormode(FALSE);
         fo_hud_menu_active = FALSE;
     }

--- a/csqc/sui_sys.qc
+++ b/csqc/sui_sys.qc
@@ -285,6 +285,14 @@ float(PanelID id) sui_is_held =
 	return _hold_action_count > 0 && _hold_actions[0] == id;
 };
 
+float sui_has_hold(PanelID id) {
+  for (float i = 0; i < _hold_action_count; i++)
+    if (_hold_actions[i] == id)
+      return TRUE;
+
+  return FALSE;
+}
+
 // last clicked: is this the last action element that was clicked, good for focusing on input boxes for example
 
 float(PanelID id) sui_is_last_clicked =


### PR DESCRIPTION
We were able to process escape twice from the same input leading to the menu simultaneously closing and opening.  While here, clean up some legacy code such as MouseDown and a double new-frame check.