### PR TITLE
Restore setorigin and skip void ents

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -856,6 +856,9 @@ DEFCVAR_STRING(r_rocketlight_color, "2.0 1.0 0.25 200");
 
 .float trail_started;
 float PP_PredrawActive() {
+    if (self.voided)
+        return PREDRAW_NEXT;
+
     Phys_Advance(self, get_phys_time(self), 0);
 
     // we need to space out the particles incase we're running at very high fps

--- a/share/physics.qc
+++ b/share/physics.qc
@@ -83,14 +83,14 @@ float Phys_Push(entity e, vector offset, float dt, float phys_flags) {
     // of this, we fudge this in Phys_Impact from the server side.
     traceline(e.origin, e.origin + offset, trace_flags, e);
 
-    if ((phys_flags & PHYSF_FAIL_STARTSOLID) && trace_startsolid) {
-        return trace_fraction;
-    }
+    if ((phys_flags & PHYSF_FAIL_STARTSOLID) && trace_startsolid)
+        return FALSE;
 
     e.origin = trace_endpos;
 
     if (trace_fraction < 1) {
-        if ((e.flags & FL_ONGROUND == 0 || e.groundentity != trace_ent))
+        setorigin(e, trace_endpos);
+        if ((e.flags & FL_ONGROUND == 0) || e.groundentity != trace_ent)
             Phys_Impact(e, trace_fraction * dt, phys_flags);
         return FALSE;
     }

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -704,7 +704,8 @@ void PredProj_Sound(int proj_type, float vol = 1) {
 void WeaponPred_ProjectProjectile(int fpp_type, entity projectile);
 
 void FO_Phys() {
-    Phys_Advance(self, time, 0);
+    if (!self.voided)
+        Phys_Advance(self, time, 0);
 
     float held_time, thinktime;
     // Once we lift physics, think execution comes with it.


### PR DESCRIPTION
Radius searches on explosion need the earlier setorigin it seems.