### PR TITLE
Reduce bandwidth used by ~25%

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -580,7 +580,6 @@ float is_observer;
 float oldhealth;
 float painfinished;
 vector thisorigin;
-float speed;
 float jump_counter;
 float grentimer_waiting;
 float jumpsound_cooldown;

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -487,10 +487,6 @@ void _Sync_ServerCommandFrame() {
     if (is_spectator)
         is_observer = FALSE;
 
-    vector vel = [getstatf(STAT_VELOCITY_X), getstatf(STAT_VELOCITY_Y),
-                  getstatf(STAT_VELOCITY_Z)];
-    speed = sqrt(vel.x * vel.x + vel.y * vel.y);
-
     local float health = getstatf(STAT_HEALTH);
     if (health <= 0 || player_class != PC_SNIPER) {
         zoomed_in = 0;

--- a/csqc/status.qc
+++ b/csqc/status.qc
@@ -1157,7 +1157,7 @@ var FO_Hud_Panel Hud_Panels[] = {
     {"gun6","Grenade Launcher",           '-4 -90',  '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_GRENADE_LAUNCHER);}, 0, 36},
     {"gun7","Rocket Launcher",            '-4 -70',  '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_ROCKET_LAUNCHER);}, 0, 36},
     {"gun8","Lighning Gun",               '-4 -50',  '36 24',  0.8,1.4,1,0, drawInvIconPanel, {return getGunIcon(IT_LIGHTNING);}, 0, 36},
-    {"speed","Speed",                     '4 15',    '26 26',  1,1.4,0,0, drawTextPanel, {return CVARF(fo_fte_hud) ? sprintf("%3.1f UPS", speed) : "";}, 0, 4},
+    {"speed","Speed",                     '4 15',    '26 26',  1,1.4,0,0, drawTextPanel, {return CVARF(fo_fte_hud) ? sprintf("%3.1f UPS", vlen(pmove_vel)) : "";}, 0, 4},
 };
 
 //var FO_Hud_Panel Hud_ExtraPanels[] = {

--- a/share/defs.h
+++ b/share/defs.h
@@ -1507,14 +1507,11 @@ enumflags {
 #define STAT_TEAMNO             33
 #define STAT_FLAGS              34
 #define STAT_CLASS              35
-#define STAT_VELOCITY_X         36
-#define STAT_VELOCITY_Y         37
-#define STAT_VELOCITY_Z         38
-#define STAT_NO_GREN1           39
-#define STAT_NO_GREN2           40
-#define STAT_TP_GREN1           41
-#define STAT_TP_GREN2           42
-#define STAT_PAUSED             43
+#define STAT_NO_GREN1           36
+#define STAT_NO_GREN2           37
+#define STAT_TP_GREN1           38
+#define STAT_TP_GREN2           39
+#define STAT_PAUSED             40
 
 // Dimensions
 #define DMN_FLASH 1 // when flashed, we set dimension see to this

--- a/ssqc/world.qc
+++ b/ssqc/world.qc
@@ -333,7 +333,6 @@ void () worldspawn = {
     clientstat(STAT_TEAMNO, EV_FLOAT, team_no);
     clientstat(STAT_FLAGS, EV_FLOAT, stat_flags);
     clientstat(STAT_CLASS, EV_FLOAT, playerclass);
-    clientstat(STAT_VELOCITY_X, EV_VECTOR, velocity); //STAT_VELOCITY_Y and Z are automaticaly defined with this too, because vector
     clientstat(STAT_NO_GREN1, EV_FLOAT, no_grenades_1);
     clientstat(STAT_NO_GREN2, EV_FLOAT, no_grenades_2);
     clientstat(STAT_TP_GREN1, EV_FLOAT, tp_grenades_1);


### PR DESCRIPTION
Velocity was embedded into a stat field for speed display on the HUD.  This is a non-optimal choice both because it changes incredibly quickly and a better (more up-to-date) copy is already available client side in the form of pmove.

Reduces BW used from ~60k/s to 45k/s.  Should also likely help with proxy overflows.