### PR TITLE
Fix Instakill Tranqs

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -185,7 +185,7 @@ void WPP_Status() {
     PRINT_CONFIG(max_rewind_fast_projectile_ms);
     PRINT_CONFIG(rewind_fast_projectile_thresh);
 
-    static string clown_desc[] = { "Rubber grenades", "Proj gravity" };
+    static string clown_desc[] = { "Rubber grenades", "Proj gravity", "Lethal tranq" };
     if (fo_config.clown_flags) {
         printf("Clown mode:\n");
         printf(" .clown gravity=%d\n", fo_config.clown_grav);

--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -24,6 +24,7 @@ var struct {
 enumflags {
     CLOWN_RUBBERGREN,
     CLOWN_PROJ_GRAVITY,
+    CLOWN_LETHAL_TRANQ,
 };
 
 inline float IsClownMode(int flag) {

--- a/ssqc/spy.qc
+++ b/ssqc/spy.qc
@@ -1097,8 +1097,12 @@ void () W_FireTranq = {
 void () T_TranqDartTouch = {
     local entity timer;
 
-    if (other.solid == 1)
+    if (other.solid == SOLID_TRIGGER)
         return;
+
+    if (self.voided)
+        return;
+    self.voided = 1;
 
     if (pointcontents(self.origin) == CONTENT_SKY) {
         dremove_sent(self);
@@ -1134,7 +1138,9 @@ void () T_TranqDartTouch = {
         }
         spawn_touchblood(9);
         deathmsg = 25;
-        TF_T_Damage(other, self, self.owner, 20, 2, 2);
+
+        float dmg = IsClownMode(CLOWN_LETHAL_TRANQ) ? 999 : 20;
+        TF_T_Damage(other, self, self.owner, dmg, 2, 2);
     } else {
         WriteByte(4, 23);
         if (self.classname == "wizspike") {


### PR DESCRIPTION
Delayed entity removal was allowing for multiple touches dependent on ping, angle, and newmis.  But keep a clown mode that allows it.