### PR TITLE
Augment, don't override flags when popping up shock grenades

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1263,6 +1263,11 @@ float PredProjectile_MatchProjectile() {
 
 // Called on `self`.
 void InitProjectileEnt(float sendflags) {
+    if (self.fpp.index == FPP_NONE) {
+      printf("ERROR: Missing FPP flags=%d\n", sendflags);
+      self.fpp.index = FPP_RAILGUN;  // Something people will notice.
+    }
+
     self.drawmask = MASK_ENGINE;
     self.predraw = PP_PredrawActive;
     if (sendflags & FOPP_ANGLES == 0)

--- a/ssqc/tsoldier.qc
+++ b/ssqc/tsoldier.qc
@@ -101,7 +101,7 @@ void () ShockGrenadeExplode = {
     self.nextthink = time + 0.7;
     self.playerclass = 0;
     self.think = NailGrenLaser;
-    self.SendFlags = FOPP_POS;
+    self.SendFlags |= FOPP_POS | FOPP_MOVETYPE;
 };
 
 void () BurstGrenadeExplode = {


### PR DESCRIPTION
We're seeing the occasional disconnect where a projectile is missing its type. But this should always be sent; seems to happen to HPBs.  One guess is maybe the original packet is being lost on a shock grenade and then flags is being smashed by the movetype update?  Ensure this doesn't happen by ORing (and make sure we actually pass back the movetype -- didn't matter since no vel).

In the meantime, prevent it from crashing by giving it a (intentionally probably wrong) model.