### PR TITLE
Automatic minping

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -447,6 +447,9 @@ void CSQC_Shutdown() = {
     FO_WriteSettings();
 }
 
+// We can query, but not set via an autocvar.
+DEFCVAR_FLOAT(cl_delay_packets, 0);
+
 float last_servercommandframe;
 void _Sync_ServerCommandFrame() {
     // Server command frames are monotonically unique, we can skip processing
@@ -479,6 +482,8 @@ void _Sync_ServerCommandFrame() {
         setviewprop(VF_AFOV, cvar("fov"));
         setsensitivityscaler(1);
     }
+
+    UpdateMinPing();
 }
 
 float last_clientcommandframe;

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -128,6 +128,7 @@ static float CalcPredEnabled(float current_enable,
 }
 
 #define ENABLE_CHECK_PERIOD 2
+static float client_delay_packets;
 static float next_wpp_enable_check;
 static float next_ping_update;
 void(float seat, string keyname, string newvalue) setlocaluserinfo = #0:setlocaluserinfo;
@@ -159,8 +160,11 @@ void WPP_Status() {
     fill_avg_ping(&avg, &variance);
     printf(" inst_ping = %d client_ping = %d avg_ping = %d var = %d\n",
             ping, pstate_server.client_ping, avg, variance);
+    if (fo_config.min_ping_ms)
+        printf(" client_delay_packets = %d\n", client_delay_packets);
 
     printf("Config:\n");
+    PRINT_CONFIG(min_ping_ms);
     PRINT_CONFIG(qc_physics);
     PRINT_CONFIG(static_newmis_ms);
     PRINT_CONFIG(dynamic_newmis_ms);
@@ -261,6 +265,72 @@ void WPP_UpdateEnable(float force) {
 
     if (pengine.pweap_ent != __NULL__)
         WP_UpdateViewModel(pengine.pweap_ent);
+}
+
+DEFCVAR_FLOAT(fo_minping_min, 0);    // Can be used to set a lower-bound on
+                                     // what minping will be chosen.
+DEFCVAR_FLOAT(cl_delay_packets, 0);  // Can be used to query, but not set.
+
+void UpdateMinPing() {
+    static float next_update;
+    if (!fo_config.min_ping_ms || time < next_update)
+        return;
+    next_update = time + 1;
+
+    const float PING_SAMPLES = 10;
+    static float num_samples;
+    static float ping_cache[PING_SAMPLES];
+    static float once;
+
+    if (CVARF(cl_delay_packets) != client_delay_packets) {
+        // We expect to see a one-time mismatch, but after this, clients are
+        // trying to change it on us.  Make that noisy.
+        if (once)
+            localcmd(sprintf("say forced reset delay_packets %d -> %d\n",
+                        CVARF(cl_delay_packets), client_delay_packets));
+        once = TRUE;
+
+        next_update = time + 0.1;
+        localcmd(sprintf("cl_delay_packets %d\n", client_delay_packets));
+        return;
+    }
+
+    float cache_index = (num_samples++) % ping_cache.length;
+    ping_cache[cache_index] =
+        max(0, getplayerkeyfloat(player_localnum, INFOKEY_P_PING));
+
+    if (num_samples < 10)
+        return;
+
+    float ping = ping_cache[0];
+    for (int i = 1; i < ping_cache.length; i++)
+        ping = min(ping, ping_cache[i]);
+
+    ping = max(ping - client_delay_packets, SERVER_FRAME_MS);
+    float target = max(fo_config.min_ping_ms - ping, 0);
+
+    if (CVARF(fo_minping_min) > 0)
+        target = max(target, CVARF(fo_minping_min));
+
+    if (!is_player)
+        target = 0;
+
+    if (target == 0) {
+        client_delay_packets = 0;
+    } else {
+        float nv = (ceil((target - 0.1)/ 3)) * 3 + 1;
+        // Bound how much we'll step at once.
+        if (!client_delay_packets)
+            client_delay_packets = nv;
+        else
+            client_delay_packets = min(client_delay_packets + 5, nv);
+    }
+
+    if (CVARF(cl_delay_packets) != client_delay_packets) {
+        localcmd(sprintf("cl_delay_packets %d\n", client_delay_packets));
+        setlocaluserinfo(0, "client_delay_packets", ftos(client_delay_packets));
+        num_samples = 0;
+    }
 }
 
 float IsEffectFrame() {

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -271,9 +271,24 @@ DEFCVAR_FLOAT(fo_minping_min, 0);    // Can be used to set a lower-bound on
                                      // what minping will be chosen.
 DEFCVAR_FLOAT(cl_delay_packets, 0);  // Can be used to query, but not set.
 
+static void set_minping_delay_packets() {
+    localcmd(sprintf("cl_delay_packets %d\n", client_delay_packets));
+    setlocaluserinfo(0, "client_delay_packets", ftos(client_delay_packets));
+}
+
 void UpdateMinPing() {
     static float next_update;
-    if (!fo_config.min_ping_ms || time < next_update)
+
+    if (!fo_config.min_ping_ms) {
+        // Clear, if-and-only-if, we control the value.
+        if (client_delay_packets) {
+            client_delay_packets = 0;
+            set_minping_delay_packets();
+        }
+        return;
+    }
+
+    if (time < next_update)
         return;
     next_update = time + 1;
 
@@ -291,7 +306,7 @@ void UpdateMinPing() {
         once = TRUE;
 
         next_update = time + 0.1;
-        localcmd(sprintf("cl_delay_packets %d\n", client_delay_packets));
+        set_minping_delay_packets();
         return;
     }
 
@@ -323,11 +338,11 @@ void UpdateMinPing() {
         if (!client_delay_packets)
             client_delay_packets = nv;
         else
-            client_delay_packets = min(client_delay_packets + 5, nv);
+            client_delay_packets = min(client_delay_packets + 10, nv);
     }
 
     if (CVARF(cl_delay_packets) != client_delay_packets) {
-        localcmd(sprintf("cl_delay_packets %d\n", client_delay_packets));
+        set_minping_delay_packets();
         setlocaluserinfo(0, "client_delay_packets", ftos(client_delay_packets));
         num_samples = 0;
     }

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1169,6 +1169,22 @@ void (float ox) W_FireSpikes = {
 
 static float QcPhysics() { return fo_config.qc_physics; }
 
+static float CanThrowGrenade(int gren_type) {
+    if (pstate_pred.client_time < pstate_pred.last_prime + 0.8)
+        return FALSE;  // Not time to throw yet, THROWING set if necessary.
+
+    float last_possible_throw = pstate_pred.last_prime + 3.7;
+    last_possible_throw -= FO_RewindGrenDt(gren_type);
+
+    // We're conservative here, a missed predicted projectile throw into what's
+    // actually a held grenade is frustrating.  Better to leave it up to the
+    // server when it's really tight.
+    if (pstate_pred.client_time > last_possible_throw - 1.5 * SERVER_FRAME_DT)
+        return FALSE;  // Buckle up... probably.
+
+    return TRUE;
+}
+
 static void W_ThrowGren(float is_throw) {
     if (!QcPhysics() || !RewindFlagEnabled(REWIND_GRENADES))
         return;
@@ -1181,20 +1197,10 @@ static void W_ThrowGren(float is_throw) {
     else if (pstate_pred.tfstate & TFSTATE_GRENTHROWING == 0)
         return;
 
-    if (pstate_pred.client_time < pstate_pred.last_prime + 0.8)
-        return;  // Not time to throw yet, THROWING set if necessary.
-
     int type_index = (pstate_pred.tfstate & TFSTATE_GREN1_PRIMED) ? 0 : 1;
     int gren_type = FO_ClassGren(pstate_pred.playerclass, type_index)->id;
-
-    float last_possible_throw = pstate_pred.last_prime + 3.7;
-    last_possible_throw -= FO_RewindGrenDt(gren_type);
-
-    // We're conservative here, a missed predicted projectile throw into what's
-    // actually a held grenade is frustrating.  Better to leave it up to the
-    // server when it's really tight.
-    if (pstate_pred.client_time > last_possible_throw - 1.5 * SERVER_FRAME_DT)
-        return;  // Buckle up... probably.
+    if (!CanThrowGrenade(gren_type) && !IsClownMode(CLOWN_SPAM_GRENADES))
+        return;
 
     if (IsEffectFrame()) {
         entity gren = PP_CreateProjectile(FPP_HANDGRENADE, '0 0 0');

--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -76,6 +76,7 @@ enumflags {
     CLOWN_LETHAL_TRANQ,
     CLOWN_STICKY_GRENS,
     CLOWN_STICKY_PIPES,
+    CLOWN_SPAM_GRENADES,
 };
 
 string CLOWN_DESC[] = {
@@ -85,6 +86,7 @@ string CLOWN_DESC[] = {
     "elephant tranq",
     "sticky grenades",
     "sticky pipes",
+    "no grenade prime-time",
 };
 
 inline float IsClownMode(int flag) {

--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -22,6 +22,8 @@ enumflags {
 };
 
 var struct {
+    float min_ping_ms;
+
     float qc_physics;
     float static_newmis_ms;
     float dynamic_newmis_ms;

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -374,6 +374,7 @@ float WP_SendConfig(entity to_player, float sendflags) {
 void EntUpdate_Config() {
 #endif
     COMM(Byte, qc_physics);
+    COMM(Byte, min_ping_ms);
     COMM(Float, static_newmis_ms);
     COMM(Float, dynamic_newmis_ms);
     COMM(Byte, max_rewind_ms);
@@ -556,6 +557,7 @@ void EntUpdate_Projectile(float isnew) {
 
 
 void Predict_InitDefaultConfig() {
+    fo_config.min_ping_ms = 0;
     fo_config.qc_physics = 1;
     fo_config.static_newmis_ms = 50;
     fo_config.dynamic_newmis_ms = 0;
@@ -604,6 +606,7 @@ static void WeaponPred_CheckConfigUpdate() {
 
     // Target is also the long form localinfo name.
     CONFIG_UPDATE("qcp", qc_physics);
+    CONFIG_UPDATE("mpm", min_ping_ms);
     CONFIG_UPDATE("snm", static_newmis_ms);
     CONFIG_UPDATE("dnm", dynamic_newmis_ms);
     CONFIG_UPDATE("mrt", max_rewind_ms);

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -1122,7 +1122,8 @@ void () FO_ThrowGrenade = {
     if (RewindFlagEnabled(REWIND_GRENADES))
         throwtime = bounded_remote_time(FO_RewindGrenDt(timer.fpp.gren_type));
 
-    if (timer.nextthink != timer.heat || timer.heat - time < 0.1) {
+    if ((timer.nextthink < timer.heat || throwtime > timer.heat - lockout) &&
+        !IsClownMode(CLOWN_SPAM_GRENADES)) {
         // We do not allow throwing within the 0.8s, or the last 0.1s.
         // The former is a priming time, the latter is so that client side
         // knockback will be able to reliably predict whether a grenade was held

--- a/ssqc/tsoldier.qc
+++ b/ssqc/tsoldier.qc
@@ -94,6 +94,7 @@ void () ShockGrenadeExplode = {
     }
     self.no_active_nail_grens = self.owner.no_active_nail_grens;
     self.movetype = MOVETYPE_FLY;
+    self.velocity = '0 0 0';
     setorigin(self, self.origin + '0 0 32');
     if(solid_nailgren) {
         setsize(self, '-1 -1 -1', '1 1 1');


### PR DESCRIPTION
Add Support for synchronizing clients to an automatic minping.

Configured via `localinfo min_ping_ms x` (or mpm for short).  Cooperating clients will automatically calibrate their delay-packets in a uniform fashion.