### PR TITLE
Run jump prediction of leading client frame for now

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -494,22 +494,12 @@ void _Sync_ServerCommandFrame() {
     UpdateMinPing();
 }
 
-float last_clientcommandframe;
-// REQUIRES: Must be called after _Sync_ServerCommandFrame.
-void _Sync_ClientCommandFrame() {
-    // Client command frames are regenerated beyond the server frame, so we
-    // cannot check that we have not seen this client command frame alone.
-    if (last_servercommandframe == servercommandframe &&
-            last_clientcommandframe == clientcommandframe)
-        return;
-    last_clientcommandframe = clientcommandframe;
-}
 
 // Called for each {client, server} command frame, ensures globals are
 // synchronized with server and predicted state.
 void Sync_GameState() {
     _Sync_ServerCommandFrame();
-    _Sync_ClientCommandFrame();
+    PM_PredictJump();
 }
 
 static string to_precision(float f, float p) {

--- a/csqc/pmove.qc
+++ b/csqc/pmove.qc
@@ -2,7 +2,7 @@ const vector PLAYER_MINS = [-16, -16, -24];
 const vector PLAYER_MAXS = [16, 16, 32];
 
 inline float CSQC_JumpSounds_Active() {
-    return WP_Enabled() && CVARF(fo_csjumpsounds);
+    return CVARF(fo_csjumpsounds);
 }
 
 // Sets *type to whatever is at the feet of `point`.
@@ -23,10 +23,18 @@ static float PM_GetWaterLevel(vector point, float* type) {
 }
 
 void PM_PredictJump() {
-    if (!CVARF(fo_csjumpsounds) || getstatf(STAT_PAUSED))
+    if (!CSQC_JumpSounds_Active() || getstatf(STAT_PAUSED))
         return;
 
+    static float last_clientframe;
     static float last_onground, last_waterlevel, last_vel_z;
+
+    if (!getinputstate(clientcommandframe) || input_timelength <= 0)
+        return;
+
+    if (time <= last_clientframe)
+        return;
+    last_clientframe = time;
 
     float fluidtype;
     float waterlevel = PM_GetWaterLevel(pmove_org, &fluidtype);
@@ -41,9 +49,6 @@ void PM_PredictJump() {
         last_waterlevel = 0;
         return;
     }
-
-    if (!IsEffectFrameMulti())
-        return;
 
     static float swimsound_next;
 

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1466,8 +1466,6 @@ void WP_UpdateViewModel() {
     viewmodel.lerpfrac = max(0, viewmodel.lerpfrac - frametime * 10);
 }
 
-void PM_PredictJump();
-
 float WP_ClientThink() {
     if (!WP_Enabled())
         return PREDRAW_NEXT;
@@ -1505,7 +1503,6 @@ float WP_ClientThink() {
         if (input_impulse)
           pstate_pred.impulse = input_impulse;
 
-        PM_PredictJump();
         WP_Frame();
     }
 


### PR DESCRIPTION
We can't recover prior pmove vals from getinputstate so until we're running pmove, just snoop the trailing edge of clientcommandframe.