### PR TITLE
Fix autocvars around prior FOCMD defines

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -810,13 +810,6 @@ string FO_ScoreBoardColumns[] = {
     "dmgt"
 };
 
-#define FOCMD_OLDSCOREBOARD "fo_oldscoreboard"
-#define FOCMD_GRENTIMER "fo_grentimer"
-#define FOCMD_GRENTIMERSOUND "fo_grentimersound"
-#define FOCMD_GRENTIMERVOLUME "fo_grentimervolume"
-#define FOCMD_JUMPVOLUME "fo_jumpvolume"
-#define FOCMD_ADMIN_MENU_UPDATE_TIME "fo_adminrefresh"
-
 DEFCVAR_FLOAT(fo_fte_hud, 0);
 DEFCVAR_FLOAT(fo_legacy_sbar, 0);
 DEFCVAR_FLOAT(fo_csjumpsounds, 1);

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -320,7 +320,7 @@ DEFCVAR_FLOAT(fo_grentimer_debug, 0);
 
 string cached_timer;
 string GetGrenTimerSound() {
-    string wav = CVARS(FOCMD_GRENTIMERSOUND);
+    string wav = CVARS(fo_grentimersound);
 
     if (cached_timer != wav) {
         precache_sound(wav);
@@ -334,7 +334,7 @@ void CsGrenTimer::StartSound() {
         return;
 
     string wav = GetGrenTimerSound();
-    float volume = CVARF(FOCMD_GRENTIMERVOLUME);
+    float volume = CVARF(fo_grentimervolume);
 
     // Note there's a bug where soundupdate returns false for a new sample, even
     // though it's started.
@@ -381,7 +381,7 @@ void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
         return;
 
     local float timer_flags = 0;
-    switch (CVARF(FOCMD_GRENTIMER)) {
+    switch (CVARF(fo_grentimer)) {
         case 0: break;
         case 1: timer_flags = FL_GT_SOUND; break;
         // 2 [and something sane for anything we don't recognize.]

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -229,7 +229,7 @@ noref float(string cmd) CSQC_ConsoleCommand = {
             Menu_Cancel();
             break;
         case "+fo_showscores":
-            if (CVARF(FOCMD_OLDSCOREBOARD) == 1)
+            if (CVARF(fo_oldscoreboard) == 1)
             {
                 tokenize(findkeysforcommand(argv(0)));
 
@@ -258,7 +258,7 @@ noref float(string cmd) CSQC_ConsoleCommand = {
         case "+showscores":
         case "+showteamscores":
             showingscores = TRUE;
-            if (CVARF(FOCMD_OLDSCOREBOARD) != 1)
+            if (CVARF(fo_oldscoreboard) != 1)
             {
                 tokenize(findkeysforcommand(argv(0)));
 
@@ -457,6 +457,7 @@ void CSQC_Shutdown() = {
 
 // We can query, but not set via an autocvar.
 DEFCVAR_FLOAT(cl_delay_packets, 0);
+DEFCVAR_FLOAT(fov, 90);
 
 float last_servercommandframe;
 void _Sync_ServerCommandFrame() {
@@ -484,10 +485,10 @@ void _Sync_ServerCommandFrame() {
     }
 
     if (zoomed_in) {
-        setviewprop(VF_AFOV, cvar("fov")/3);
+        setviewprop(VF_AFOV, CVARF(fov))/3;
         setsensitivityscaler(1/3);
     } else {
-        setviewprop(VF_AFOV, cvar("fov"));
+        setviewprop(VF_AFOV, CVARF(fov));
         setsensitivityscaler(1);
     }
 

--- a/csqc/pmove.qc
+++ b/csqc/pmove.qc
@@ -1,3 +1,5 @@
+DEFCVAR_FLOAT(fo_jumpvolume, 1);
+
 const vector PLAYER_MINS = [-16, -16, -24];
 const vector PLAYER_MAXS = [16, 16, 32];
 
@@ -80,7 +82,7 @@ void PM_PredictJump() {
             //    stairs when combined with (1).  We can test for this by
             //    watching to see whether we actually got a sufficiently large
             //    velocity increase.
-            localsound("player/plyrjmp8.wav", CHAN_AUTO, cvar(FOCMD_JUMPVOLUME));
+            localsound("player/plyrjmp8.wav", CHAN_AUTO, CVARF(fo_jumpvolume));
         }
     }
 

--- a/csqc/settings.qc
+++ b/csqc/settings.qc
@@ -1,9 +1,8 @@
 // Saved/Loaded/Restored by Settings funcs
-DEFCVAR_FLOAT(FOCMD_GRENTIMER, 2);  // Sound + Ping adjust
-DEFCVAR_STRING(FOCMD_GRENTIMERSOUND, "grentimer.wav");
-DEFCVAR_FLOAT(FOCMD_GRENTIMERVOLUME, 1);
-DEFCVAR_FLOAT(FOCMD_JUMPVOLUME, 1);
-DEFCVAR_FLOAT(FOCMD_OLDSCOREBOARD, 0);
+DEFCVAR_FLOAT(fo_grentimer, 2);  // Sound + Ping adjust
+DEFCVAR_STRING(fo_grentimersound, "grentimer.wav");
+DEFCVAR_FLOAT(fo_grentimervolume, 1);
+DEFCVAR_FLOAT(fo_oldscoreboard, 0);
 
 // CVARS that just pass via regular config state.
 DEFCVAR_FLOAT(fo_hud_idle_alpha, 0.3);
@@ -23,28 +22,34 @@ string FormatCfgVector(string line, string field, vector value)
     return line;
 }
 
+const string FOCMD_OLDSCOREBOARD = "fo_oldscoreboard";
+const string FOCMD_GRENTIMER = "fo_grentimer";
+const string FOCMD_GRENTIMERSOUND = "fo_grentimersound";
+const string FOCMD_GRENTIMERVOLUME = "fo_grentimervolume";
+const string FOCMD_JUMPVOLUME = "fo_jumpvolume";
+const string FOCMD_ADMIN_MENU_UPDATE_TIME = "fo_adminrefresh";
 
 void FO_WriteSettings()
 {
     // this overwrites
     float filehandle;
     filehandle = fopen(FO_CONFIG_PATH, FILE_WRITE);
-    string line = FormatCfgString("", FOCMD_GRENTIMER, ftos(CVARF(FOCMD_GRENTIMER)));
-    line = FormatCfgString(line, FOCMD_GRENTIMERSOUND, CVARS(FOCMD_GRENTIMERSOUND));
-    line = FormatCfgString(line, FOCMD_GRENTIMERVOLUME, ftos(CVARF(FOCMD_GRENTIMERVOLUME)));
-    line = FormatCfgString(line, FOCMD_JUMPVOLUME, ftos(CVARF(FOCMD_JUMPVOLUME)));
-    line = FormatCfgString(line, FOCMD_OLDSCOREBOARD, ftos(CVARF(FOCMD_OLDSCOREBOARD)));
+    string line = FormatCfgString("", FOCMD_GRENTIMER, ftos(CVARF(fo_grentimer)));
+    line = FormatCfgString(line, FOCMD_GRENTIMERSOUND, CVARS(fo_grentimersound));
+    line = FormatCfgString(line, FOCMD_GRENTIMERVOLUME, ftos(CVARF(fo_grentimervolume)));
+    line = FormatCfgString(line, FOCMD_JUMPVOLUME, ftos(CVARF(fo_jumpvolume)));
+    line = FormatCfgString(line, FOCMD_OLDSCOREBOARD, ftos(CVARF(fo_oldscoreboard)));
     fputs(filehandle, line);
     fclose(filehandle);
 }
 
 void FO_LoadDefaultSettings()
 {
-    CVARF(FOCMD_GRENTIMER) = 2;
-    CVARS(FOCMD_GRENTIMERSOUND) = "grentimer.wav";
-    CVARF(FOCMD_GRENTIMERVOLUME) = 1;
-    CVARF(FOCMD_JUMPVOLUME) = 1;
-    CVARF(FOCMD_OLDSCOREBOARD) = 0;
+    CVARF(fo_grentimer) = 2;
+    CVARS(fo_grentimersound) = "grentimer.wav";
+    CVARF(fo_grentimervolume) = 1;
+    CVARF(fo_jumpvolume) = 1;
+    CVARF(fo_oldscoreboard) = 0;
 }
 
 void FO_LoadSettings()
@@ -74,19 +79,19 @@ void FO_LoadSettings()
                 switch(field)
                 {
                     case FOCMD_GRENTIMER:
-                        CVARF(FOCMD_GRENTIMER) = stof(val);
+                        CVARF(fo_grentimer) = stof(val);
                         break;
                     case FOCMD_GRENTIMERSOUND:
-                        CVARS(FOCMD_GRENTIMERSOUND) = val;
+                        CVARS(fo_grentimersound) = val;
                         break;
                     case FOCMD_GRENTIMERVOLUME:
-                        CVARF(FOCMD_GRENTIMERVOLUME) = stof(val);
+                        CVARF(fo_grentimervolume) = stof(val);
                         break;
                     case FOCMD_JUMPVOLUME:
-                        CVARF(FOCMD_JUMPVOLUME) = stof(val);
+                        CVARF(fo_jumpvolume) = stof(val);
                         break;
                     case FOCMD_OLDSCOREBOARD:
-                        CVARF(FOCMD_OLDSCOREBOARD) = stof(val);
+                        CVARF(fo_oldscoreboard) = stof(val);
                         break;
                 }
             }


### PR DESCRIPTION
This was generating compilable, but not correct code that would end up using FOCMD_... for cvar definitions.  This was further masked by an incorrect use of cvar() sneaking back into the code that allowed it to pick up the legacy value on a client that had previously defined it (although it would be missing on a new install).

While we're here, shoot another cvar() that's crept in around fov.