### PR TITLE
Better matching of melee animations

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -440,6 +440,16 @@ void WP_ServerUpdate() {
     if (pstate_server.attack_finished < pstate_server.client_time)
         pstate_server.weaponframe = 0;
 
+    // Match up melee animations when they don't match.  The easiest way for
+    // this to happen is effectframe miss.
+    if (pstate_server.weaponframe >= 1 && pstate_server.weaponframe < 8 &&
+        pstate_pred.weaponframe >= 1 && pstate_pred.weaponframe < 8) {
+        pstate_server.weaponframe = (pstate_server.weaponframe - 1) % 4;
+        if (pstate_pred.weaponframe >= 4)
+            pstate_server.weaponframe += 4;
+        pstate_server.weaponframe += 1;
+    }
+
     if (CVARF(fo_wpp_beta) == 2)
         phys_sim_dt = (pstate_server.client_ping + 2 * SERVER_FRAME_MS) / 1000.0;
     else

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -366,6 +366,7 @@ float() ReadCoord = #364;
 float() ReadAngle = #365;
 float() ReadFloat = #367;
 float() ReadEntity = #368;
+int() ReadInt = #0:readint;
 
 void InitWeapPredEnt(entity e);
 void WP_ServerUpdate();
@@ -480,9 +481,9 @@ void EntUpdate_WeaponPred(float isnew) {
         COMM(Float, reload_finished);
 
     if (sendflags & FOWP_RNG0)
-        COMM(Short, prng_base[0]);
+        COMM(Int, prng_base[PRNG_WEAP]);
     if (sendflags & FOWP_RNG1)
-        COMM(Short, prng_base[1]);
+        COMM(Int, prng_base[PRNG_HWGUY]);
 
 #ifdef SSQC
     return TRUE;


### PR DESCRIPTION
Eliminate 2 sources of mismatch between client and server animation:

1) Turns out to be a general fix, readshort is signed (and writeshort will just pass through unsigned) and we were clipping the range on our base.  Leading to client and server using different prng bases for some value.

2) It's possible also to just mispredict/miss/etc.  We can filter these out by having the server animation follow the client's choice in the case we got it wrong.