### PR TITLE
Use thinkindex to reset hit_in_current_animation

### DIFF
--- a/share/animate.qc
+++ b/share/animate.qc
@@ -93,7 +93,7 @@ static void axe_extra() {
             break;
     }
 
-    if (self.weaponframe == 1)
+    if (*thinkindex() == 2)  // 1-index and already incremented.
         self.hit_in_current_animation = FALSE;
 
     if ((*flag && !self.hit_in_current_animation) ||


### PR DESCRIPTION
The starting weapon-frame is variable depending on whether the a, or b, swing animation is being used.  This could result in the multi-frame hit counter not being reset on b-swings after a-swings.  Use thinkindex() instead which is uniform across the two animations.