### PR TITLE
weapons: fix mashing +slot

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -650,6 +650,13 @@ float WP_ReloadSlot(Slot slot);
 void WP_ReloadNext();
 void WPP_Dump();
 
+static void WP_ChangeIfQueued() {
+    if (!IsSlotNull(pstate_pred.queue_slot)) {
+        WP_ChangeWeapon(pstate_pred.queue_slot);
+        pstate_pred.queue_slot = SlotNull;
+    }
+}
+
 void WP_Impulse() {
     WP_HandleHeavyInputs();
 
@@ -680,6 +687,8 @@ void WP_Impulse() {
 
     if (pstate_pred.client_time < pstate_pred.attack_finished || WP_IsReloading())
         return;
+
+    WP_ChangeIfQueued();  // Might have something previously buffered.
 
     // Impulses that ARE held by attack_finished / reloading.
     match = TRUE;
@@ -729,11 +738,7 @@ void WP_Impulse() {
             break;
     }
 
-    if (!IsSlotNull(pstate_pred.queue_slot)) {
-        WP_ChangeWeapon(pstate_pred.queue_slot);
-        pstate_pred.queue_slot = SlotNull;
-    }
-
+    WP_ChangeIfQueued();  // Might have something newly buffered.
 
     if (match)
         pstate_pred.impulse = 0;

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -2569,6 +2569,9 @@ void () W_WeaponFrame = {
     float can_change_weapon = WeaponReady();
 
     // TODO: Open up queueing by moving queue can_change to ChangeWeapon?
+    if (!IsSlotNull(self.queue_slot) && can_change_weapon)
+        W_ChangeWeaponSlot(self.queue_slot);
+
     if (self.impulse >= 1 && self.impulse <= GetMaxWeaponInput() &&
         can_change_weapon) {
         // slot 1-4 (or 1-7) binds
@@ -2586,9 +2589,6 @@ void () W_WeaponFrame = {
             W_ChangeWeaponSlot(slot);
         }
         self.impulse = 0;
-    } else if (!IsSlotNull(self.queue_slot) && can_change_weapon) {
-        // change slot if queue_slot has been set
-        W_ChangeWeaponSlot(self.queue_slot);
     }
 
     if (self.impulse == TF_CHANGETEAM) {


### PR DESCRIPTION
mashing +slot on top of +slot creates confusion since we couldn't actually process the prior weapon change from -slot even though a new +slot is queuing and overloading it.  This resulted in the state-machine valid, but confusing behavior that if you +slot before a prior -slot attack finished, then it might consider the weapon to swap back to on the second +slot as the original.  Make this more intuitive by making sure we forward the prior -slot to last-weapon before this.

probably worth improving impulse behavior immediately after this by using queue_slot to eliminate a bunch of cases for these held impulses that can be clobbered.