### PR TITLE
impulses: restore TF_CLASSMENU

### DIFF
--- a/share/defs.h
+++ b/share/defs.h
@@ -403,7 +403,7 @@ struct Slot { int id; };
 #define TF_IMPULSE_SLOT4            4   // Changes weapon to slot 4 (melee weapon)
 #define TF_NUM_SLOTS                4
 
-// unused                           5
+#define TF_CLASSMENU                5   // Brings up class menu
 // unused                           6
 // unused                           7
 // unused                           8

--- a/ssqc/tforthlp.qc
+++ b/ssqc/tforthlp.qc
@@ -84,6 +84,7 @@ void () TeamFortress_MOTD = {
         } else {
             TeamFortress_AliasString("menu", "cmd menu");
         }
+
         TeamFortress_Alias("slot1", TF_IMPULSE_SLOT1, 0);
         TeamFortress_Alias("slot2", TF_IMPULSE_SLOT2, 0);
         TeamFortress_Alias("slot3", TF_IMPULSE_SLOT3, 0);

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -2527,6 +2527,18 @@ void () W_WeaponFrame = {
         }
     }
 
+    if (self.impulse == TF_CLASSMENU && self.playerclass != PC_MEDIC) {
+        switch (self.playerclass) {
+            case PC_ENGINEER: Menu_Engineer(self); break;
+            case PC_SCOUT: Menu_Scout(); break;
+            case PC_SPY: Menu_Spy(self); break;
+            case PC_DEMOMAN: TeamFortress_DetpackMenu(); break;
+        }
+
+        self.impulse = 0;
+        return;
+    }
+
     if ((self.is_feigning) &&
             (self.impulse != TF_SPECIAL_SKILL) &&
             (self.impulse != TF_SPECIAL_SKILL_2) &&


### PR DESCRIPTION
While internal usage has migrated to `cmd menu`; there's still external use via legacy impulse 5 bind which this hits.  Just bringing it back is simplest.