### PR TITLE
grentimers: default fo_grentimer 2 to full rtt correction

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -520,7 +520,6 @@ enumflags {
     FL_GT_SOUND,
     FL_GT_THROWN,
     FL_GT_ADJPING,
-    FL_GT_FULL_RTT,
 };
 
 void(string identify) Hud_DrawIdentifyPanel;
@@ -706,7 +705,8 @@ void HRC_Render() {
     }
 }
 
-DEFCVAR_FLOAT(fo_grentimer_nostack, 0);
+DEFCVAR_FLOAT(fo_grentimer_ping_frac, 1);  // Fraction of ping to correct for.
+DEFCVAR_FLOAT(fo_grentimer_nostack, 0);    // When set, only play soonest timer.
 
 class CsGrenTimer;
 CsGrenTimer grentimers[NUM_GREN_TIMERS];

--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -394,12 +394,9 @@ void CsGrenTimer::Set(float primed_at, float expires_at, float _grentype,
     playing_ = FALSE;
 
     if (this.flags_ & FL_GT_ADJPING) {
-        float rtt = pstate_pred.client_ping;
+        float rtt = pstate_pred.client_ping * CVARF(fo_grentimer_ping_frac);
         if (RewindFlagEnabled(REWIND_GRENADES))
             rtt = max(0, rtt - (100 + FO_RewindGrenMs(TF_GREN_conv(_grentype))));
-        else if ((this.flags_ & FL_GT_FULL_RTT) == 0)
-            rtt /= 2;  // Not actually right, but preserve buggy behavior for
-                       // now as people are used to it.
         expires_at_ -= rtt / 1000;
     }
 
@@ -432,7 +429,6 @@ void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
     switch (CVARF(fo_grentimer)) {
         case 0: break;
         case 1: timer_flags = FL_GT_SOUND; break;
-        case 3: timer_flags = FL_GT_FULL_RTT;  // Intentional fall-through.
         // 2 [and something sane for anything we don't recognize.]
         default: timer_flags |= FL_GT_SOUND | FL_GT_ADJPING; break;
     }


### PR DESCRIPTION
Due to the world being interpolated an additional 1/2 rtt, our prior ping correction was slightly off.

Change the default correction to a full rtt, but also introduce `fo_grentimer_ping_frac` to control the total latency corrected.  A value of `fo_grentimer_ping_frac 0.5` will restore the behavior prior to this change.