### PR TITLE
weapons: prevent recursive detpipe

### DIFF
--- a/ssqc/demoman.qc
+++ b/ssqc/demoman.qc
@@ -20,6 +20,12 @@ float (float force) TeamFortress_DetonatePipebombs = {
     if (time < self.pipecooldown && !force)
         return impulse_queue ? FALSE : TRUE;
 
+    if (self.detpipe_nesting > 0)
+        return TRUE;
+    // It's possible that we'll kill ourselves when we detonate pipebombs and
+    // initiate a nested det; exclude this to avoid iterating removed ents.
+    self.detpipe_nesting++;
+
     int count;
     entity* pipes = find_list(classname, "pipebomb", EV_STRING, count);
 
@@ -42,9 +48,11 @@ float (float force) TeamFortress_DetonatePipebombs = {
         }
     }
 
+    // NOTE: nested death-dets would not trigger double unwind due to `force==1`
     if (rewound)
         FOPlayer::RestoreAll();
 
+    self.detpipe_nesting--;
     return TRUE;
 };
 

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -85,6 +85,7 @@ float remote_client_time();
 .float vote_close;              // TRUE if player has closed the map vote, resets on spawn
 .float detpack_left;            // Seconds left to detpack explosion
 .float pipecooldown;            // Time when detpipe command can be issued
+.float detpipe_nesting;         // Used to avoid recursive detpipes when detting self
 .float disguise_skin;           // The skin the spy is changing to
 .float queue_skin;              // The skin the spy will change to after team disguise is finished
 .float last_selected_skin;      // The last skin the spy selected to disguise as


### PR DESCRIPTION
When a demoman dies, his pipebombs detonate.
When a demoman detonates his pipebombs and kills themself...
                                 ... their pipebombs... detonate.

You start to see the problem.  Re-entrancy in death handling on self-detpipe would result in nested detpipe call, however, both the parent and child calls are working on the same pipe lists and so subsequent parent execution will result in a duplicate detonation for anything handled by the child.  Resulting in spurious explosions at (0,0,0) when the removed ent is redetonated.

Fix by preventing detpipe nesting; the second case will no longer trigger a second detpipe.