### PR TITLE
impulse: remove legacy QUICKSLOT/QUICKSTOP

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -658,9 +658,6 @@ static void WP_ChangeIfQueued() {
 void WP_Impulse() {
     WP_HandleHeavyInputs();
 
-    // Note: We might have no impulse, but a queued slot here.
-    float quick_swap = FALSE;
-
     // Impulses that are NOT held by attack_finished / reloading.
     float match = TRUE;
     switch (pstate_pred.impulse) {
@@ -700,25 +697,14 @@ void WP_Impulse() {
             WP_ReloadNext();
             break;
 
-        case TF_QUICKSLOT1: case TF_QUICKSLOT2: case TF_QUICKSLOT3: case TF_QUICKSLOT4:
-            pstate_pred.impulse -= TF_QUICKSLOT1 - 1;  // Intentional fall-through.
-            quick_swap = TRUE;
         case 1: case 2: case 3: case 4: case 5: case 6: case 7: {
             Slot slot = InputToSlot(pstate_pred.impulse);
             if (!IsSlotNull(slot) && !IsSameSlot(pstate_pred.current_slot, slot)) {
-                if (quick_swap)
-                    pstate_pred.tfstate |= TFSTATE_QUICKSLOT;
                 pstate_pred.queue_slot = slot;
             }
             break;
         }
 
-        case TF_QUICKSTOP:
-            if (pstate_pred.tfstate & TFSTATE_QUICKSLOT == 0) {
-                pstate_pred.impulse = 0;
-                break;
-            }
-            pstate_pred.tfstate &= ~TFSTATE_QUICKSLOT;  // Intentional fall-through.
         case TF_WEAPLAST:
             pstate_pred.queue_slot = pstate_pred.last_slot; break;
 
@@ -1185,17 +1171,6 @@ entity PP_CreateProjectile(int fpp_type, vector offset) {
   proj.owner_entnum = player_localentnum;
   proj.owner = pengine.player_ent;
   FPP_Init(fpp_type, proj);
-
-#if 0
-  // Packet loss doesnt guarantee the server will actually register quickslot
-  // since it's a separate command from the attack.  We can improve this in the
-  // future via either a button or just combining them on an impulse.  But for
-  // now just dont create the projectile, it's usually swapping to a hitscan
-  // weapon anyway.
-  if (pstate_pred.tfstate & TFSTATE_QUICKSLOT &&
-      !(pstate_server.tfstate & TFSTATE_QUICKSLOT))
-      return __NULL__;
-#endif
 
   ProjectResult push_t = Forward_ProjectOffset(fpp_type, interp_ms());
 

--- a/share/defs.h
+++ b/share/defs.h
@@ -252,7 +252,6 @@ enumflags {
                            // (Note: We don't use NO_WEAPON for reloading
                            // as it could result in stacked no-weapon states.)
     TFSTATE_FLASHED,
-    TFSTATE_QUICKSLOT,     // QUICKSTOP should change to last weapon.
     TFSTATE_AC_SPINUP,     // These cover the 3 assault cannon states.
     TFSTATE_AC_SPINNING,
     TFSTATE_AC_SPINDOWN,
@@ -418,11 +417,11 @@ struct Slot { int id; };
 #define TF_GRENADE_PT_1             17  // Prime and throw grenade type 1 (two clicks)
 #define TF_GRENADE_PT_2             18  // Prime and throw grenade type 2 (two clicks)
 #define TF_GRENADE_SWITCH           19  // Switch grenade mode 1/2
-#define TF_QUICKSLOT1               20  // Fire weapon slot 1 and then switch back to current weapon
-#define TF_QUICKSLOT2               21  // Fire weapon slot 2 and then switch back to current weapon
-#define TF_QUICKSLOT3               22  // Fire weapon slot 3 and then switch back to current weapon
-#define TF_QUICKSLOT4               23  // Fire weapon slot 4 and then switch back to current weapon
-#define TF_QUICKSTOP                24  // Used to tell server that quick firing has stopped
+// unused                           20
+// unused                           21
+// unused                           22
+// unused                           23
+// unused                           24
 #define TF_RELOAD_SLOT1             25  // Reload weapon slot 1
 #define TF_RELOAD_SLOT2             26  // Reload weapon slot 2
 #define TF_RELOAD_SLOT3             27  // Reload weapon slot 3

--- a/ssqc/tforthlp.qc
+++ b/ssqc/tforthlp.qc
@@ -90,14 +90,14 @@ void () TeamFortress_MOTD = {
         TeamFortress_Alias("slot3", TF_IMPULSE_SLOT3, 0);
         TeamFortress_Alias("slot4", TF_IMPULSE_SLOT4, 0);
 
-        TeamFortress_AliasString("+slot1", "impulse 20;+attack");
-        TeamFortress_AliasString("-slot1", "-attack;impulse 24");
-        TeamFortress_AliasString("+slot2", "impulse 21;+attack");
-        TeamFortress_AliasString("-slot2", "-attack;impulse 24");
-        TeamFortress_AliasString("+slot3", "impulse 22;+attack");
-        TeamFortress_AliasString("-slot3", "-attack;impulse 24");
-        TeamFortress_AliasString("+slot4", "impulse 23;+attack");
-        TeamFortress_AliasString("-slot4", "-attack;impulse 24");
+        TeamFortress_AliasString("+slot1", sprintf("impulse %d;+attack", TF_IMPULSE_SLOT1));
+        TeamFortress_AliasString("-slot1", sprintf("-attack;impulse %d", TF_WEAPLAST));
+        TeamFortress_AliasString("+slot2", sprintf("impulse %d;+attack", TF_IMPULSE_SLOT2));
+        TeamFortress_AliasString("-slot2", sprintf("-attack;impulse %d", TF_WEAPLAST));
+        TeamFortress_AliasString("+slot3", sprintf("impulse %d;+attack", TF_IMPULSE_SLOT3));
+        TeamFortress_AliasString("-slot3", sprintf("-attack;impulse %d", TF_WEAPLAST));
+        TeamFortress_AliasString("+slot4", sprintf("impulse %d;+attack", TF_IMPULSE_SLOT4));
+        TeamFortress_AliasString("-slot4", sprintf("-attack;impulse %d", TF_WEAPLAST));
     } else if (self.motd == 30) {
         if(csqcactive) {
             TeamFortress_AliasString("changeteam", "fo_menu_team");

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -2543,18 +2543,6 @@ void () W_WeaponFrame = {
         self.impulse = 0;
     }
 
-    // +slot/-slot handle attack; we only need to swap back to last weapon.
-    // Let's see if we can get away with just treating this as last weapon;
-    // there were already so many edge cases in the old code such as swapping on
-    // an empty weapon.
-    if (self.impulse == TF_QUICKSTOP) {
-        if (self.tfstate & TFSTATE_QUICKSLOT)
-            self.impulse = TF_WEAPLAST;
-        else
-            self.impulse = 0;
-        self.tfstate &= ~TFSTATE_QUICKSLOT;
-    }
-
     float can_change_weapon = WeaponReady();
 
     // TODO: Open up queueing by moving queue can_change to ChangeWeapon?
@@ -2565,19 +2553,6 @@ void () W_WeaponFrame = {
         can_change_weapon) {
         // slot 1-4 (or 1-7) binds
         W_ChangeWeaponByInput(self.impulse);
-        self.impulse = 0;
-    } else if (self.impulse >= TF_QUICKSLOT1 &&
-               self.impulse <= TF_QUICKSLOT4 && can_change_weapon) {
-        float input = InputHandlePyroSlotSwap(self.playerclass,
-                                              self.impulse - TF_QUICKSLOT1 + 1);
-        Slot slot = MakeSlot(input);
-
-        if (IsSameSlot(slot, self.current_slot)) {
-            self.tfstate &= ~TFSTATE_QUICKSLOT;
-        } else {
-            self.tfstate |= TFSTATE_QUICKSLOT;
-            W_ChangeWeaponSlot(slot);
-        }
         self.impulse = 0;
     }
 


### PR DESCRIPTION
This was a rat's nest of a state machine which required a bunch of unpleasant translation, state tracking, and handling.  Replace with direct invocation of the native slot and weaplast, which gets rid of all special handling of +slot on client and server.