### PR TITLE
hud: make sure we capture inputs on in game menus

### DIFF
--- a/csqc/input.qc
+++ b/csqc/input.qc
@@ -10,13 +10,12 @@ float(float evtype, float scanx, float chary, float devid) CSQC_InputEvent = {
 
         switch (evtype) {
             case IE_KEYDOWN:
-                if (fo_hud_menu_active)
-                    fo_menu_process_input(CurrentMenu, scanx);
                 if (scanx == K_ESCAPE) {
                     Menu_Cancel();
                     FO_Hud_Editor_Cancel();
                     return TRUE;  // Always capture escape
-                }
+                } else if (fo_hud_menu_active)
+                    return fo_menu_process_input(CurrentMenu, scanx);
                 break;
             case IE_MOUSEABS:
                 Mouse.x = scanx;


### PR DESCRIPTION
We cleaned up a bunch of the input capture code, one escape that was some of the in game menus such as the engineer build menu were now correctly passing through e.g. WASD consistently, however, they weren't consuming the inputs that definitely applied to them.