### PR TITLE
weapons: experimental new concussion grenade affects aim rather than …

### DIFF
--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -356,6 +356,11 @@ void() CSQC_Parse_Event = {
         case MSG_UNPAUSE:
             CsGrenTimer::SyncUnpause();
             break;
+        case MSG_CONCUSSED:
+            cuss_state.amp = readbyte();
+            cuss_state.end_time = readfloat();
+            break;
+
     }
 }
 

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -167,6 +167,7 @@ noref void() CSQC_WorldLoaded = {
     localcmd("menu_restart\n");
 }
 
+void FO_CussCrosshair(float width, float height);
 void Hud_UpdateView(float width, float height, float menushown, float perf_sample);
 
 DEFCVAR_FLOAT(fov, 90);
@@ -194,6 +195,7 @@ noref void(float width, float height, float menushown) CSQC_UpdateView = {
     RenderHitTexts();
     Hud_UpdateView(width, height, menushown, fts);
 
+    FO_CussCrosshair(width, height);
     perf_finish_sample(&frame_timing, fts);
 
     // Work around bug in some versions of FTE.  See pmove.qc
@@ -496,6 +498,82 @@ void() CSQC_Ent_Remove = {   //the entity in question left the player's pvs, and
     remove(self);
 };
 
+struct {
+    float old_x, old_y;
+    float cussed;
+    float end_time;
+    float amp;
+} cuss_state;
+
+vector FO_Conc_Offset() {
+    const float P = 4;
+
+    float rem = cuss_state.end_time - time;
+    if (rem < 0)
+        return '0 0 0';
+
+    float a = ((rem % P) / P) * 2 * M_PI;
+    float amp = 2 + cuss_state.amp * min(8, rem)/8;
+
+    float x = amp * sin(a), y = amp * sin(a) * cos(a);
+    return [x, y, 0];
+}
+
+
+vector FO_ConcAim() {
+    vector o = FO_Conc_Offset();
+
+    vector r = v_forward * 200 + o.x * v_right + o.y * v_up;
+    return normalize(r);
+}
+
+DEFCVAR_FLOAT(cl_crossx, 0);
+DEFCVAR_FLOAT(cl_crossy, 0);
+
+void FO_CussCrosshair(float width, float height) {
+    // Limit the rendering speed to reduce blur
+    static float next_update;
+    if (time < next_update)
+        return;
+    next_update += 0.025;
+
+
+    if (time >= cuss_state.end_time) {
+        if (cuss_state.cussed) {
+            // Make sure we restore crosshairs
+            localcmd(sprintf("cl_crossx %d; cl_crossy %d;\n",
+                        cuss_state.old_x, cuss_state.old_y));
+            cuss_state.cussed = FALSE;
+        }
+        return;
+    }
+
+    if (!cuss_state.cussed) {
+        /* cuss_state.old_x = CVARF(cl_crossx); */
+        /* cuss_state.old_y = CVARF(cl_crossy); */
+        cuss_state.old_x = 0; // TODO: properly save and restore these
+        cuss_state.old_y = 0;
+        cuss_state.cussed = TRUE;
+    }
+
+    makevectors(input_angles);  // updated by input_frame
+    vector p = project(pmove_org + 8000 * v_forward);
+
+    localcmd(sprintf("cl_crossx %d; cl_crossy %d;\n",
+                cuss_state.old_x + p_x - width / 2,
+                cuss_state.old_y + p_y - height / 2));
+}
+
+void FO_UpdateCuss() {
+    if (time < cuss_state.end_time) {
+        makevectors(input_angles);
+        input_angles = vectoangles(FO_ConcAim());
+        makevectors(input_angles);
+        input_angles_x *= -1;
+    }
+
+}
+
 noref void CSQC_Input_Frame() {
     Sync_GameState();
 
@@ -513,6 +591,8 @@ noref void CSQC_Input_Frame() {
 
     if (prev_zoomed_in != zoomed_in)
         setsensitivityscaler(zoomed_in ? 1/3 : 1);
+
+    FO_UpdateCuss();
 }
 
 float(float save, float take, vector inflictororg) CSQC_Parse_Damage = {

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1082,6 +1082,7 @@ void MP_SetSpeed() {
 }
 
 
+DEFCVAR_FLOAT(cl_crossx, 0);
 
 void WP_Frame() {
     if (!is_alive) {

--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -190,7 +190,8 @@ const float SERVER_FRAME_MS = SERVER_FRAME_DT * 1000.0;
 #define MSG_TFX_GRENTIMER   25
 #define MSG_QUAD_ROUND_BEGIN   26
 #define MSG_LOGIN           27
-#define MSG_HITFLAG	    	28
+#define MSG_HITFLAG         28
+#define MSG_CONCUSSED       29
 #define FLAGINFO_HOME       1
 #define FLAGINFO_CARRIED    2
 #define FLAGINFO_DROPPED    3

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -571,6 +571,15 @@ void () DecodeLevelParms = {
         // medic immune to concussion grenade effects [on]
         medicnocuss = CF_GetSetting("mnc", "medicnocuss", "on");
 
+        // aim based concussion grenade effect
+        fo_concuss = CF_GetSetting("foc", "fo_cuss", "0");
+
+        // Tie some of these other options together for convenience / other
+        if (fo_concuss & FOC_DISTANCE)
+            distance_based_cuss_duration = TRUE;
+        if (fo_concuss & FOC_AFF_MED)
+            medicnocuss = FALSE;
+
         // display sniper rifle power in status bar [on]
         sniperpower = CF_GetSetting("sp", "sniperpower", "on");
 

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -651,6 +651,15 @@ float engineer_move;
 
 float fo_projectiles;
 
+enumflags {
+    FOC_ON,
+    FOC_DISTANCE,
+    FOC_AFF_MED,
+    FOC_RED_MED,
+    FOC_RED_HVY,
+};
+float fo_concuss;
+
 float numlocs;
 typedef struct {vector pos; string desc;} loc_t;
 loc_t *locs;

--- a/ssqc/scout.qc
+++ b/ssqc/scout.qc
@@ -841,6 +841,13 @@ void (entity inflictor, entity attacker, float bounce,
                             speedbump.owner = head;
                         }
 
+                        if (fo_concuss & FOC_ON) {
+                            UpdateClientConcussion(head, actual_cuss_time);
+
+                            head = head.chain;
+                            continue;
+                        }
+
                         te = find(world, classname, "timer");
                         if (old_grens == TRUE)
                             while (((te.owner != head) ||

--- a/ssqc/status.qc
+++ b/ssqc/status.qc
@@ -614,6 +614,26 @@ void (entity Player) InitAllStatuses = {
     }
 };
 
+void UpdateClientConcussion(entity player, float duration) {
+    msg_entity = player;
+
+    float amp = 50;
+
+    if ((player.playerclass == PC_HVYWEAP) && (fo_concuss & FOC_RED_HVY)) {
+        amp /= 2;
+    }
+
+    if ((player.playerclass == PC_MEDIC) && (fo_concuss & FOC_RED_MED)) {
+        duration /= 2;
+    }
+
+    WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
+    WriteByte(MSG_MULTICAST, MSG_CONCUSSED);
+    WriteByte(MSG_MULTICAST, amp);
+    WriteFloat(MSG_MULTICAST, time + duration);
+    multicast('0 0 0', MULTICAST_ONE_R_NOSPECS);
+}
+
 float laststate;
 void (entity Player, entity Goal) UpdateClientButtonStatus = {
     if(!infokeyf(Player, INFOKEY_P_CSQCACTIVE))


### PR DESCRIPTION
…movement

Aim and crosshair traces a figure 8 which player must correct for, movement also subtly trends in that direction.

Variety of flags for some initial tuning, but the most basic is enabled via
  `localinfo foc 1`