### PR TITLE
experimental: restore air control / strafing

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -511,7 +511,7 @@ static float BlendAmp(float start, float end, float rem, float D) {
     return rem/D * start + (D-rem)/D * end;
 }
 
-vector FO_Conc_Offset() {
+static vector FO_Conc_Offset() {
     const float P = 4;
 
     float rem = cuss_state.end_time - time;
@@ -533,26 +533,28 @@ vector FO_Conc_Offset() {
 }
 
 
-vector FO_ConcAim() {
+static void FO_UpdateConcAim() {
+    makevectors(input_angles);
     vector o = FO_Conc_Offset();
 
     vector r = v_forward * 200 + o.x * v_right + o.y * v_up;
 
-    cuss_state.view = vectoangles(v_forward * 200 + o.x/4 * v_right + o.y/4 * v_up);
-    cuss_state.view[0] *= -1;
+    cuss_state.c_view = vectoangles(v_forward * 200 + o.x/4 * v_right + o.y/4 * v_up);
+    cuss_state.c_view[0] *= -1;
 
-    return normalize(r);
+    cuss_state.c_forward = normalize(r);
 }
 
+DEFCVAR_FLOAT(fo_crossy, 0);  // For people who want to use crossy
 DEFCVAR_FLOAT(cl_crossx, 0);
 DEFCVAR_FLOAT(cl_crossy, 0);
 
-void FO_CussView() {
+static void FO_CussView() {
     if (cuss_state.cussed)
-        setproperty(VF_ANGLES, cuss_state.view);
+        setproperty(VF_ANGLES, cuss_state.c_view);
 };
 
-void FO_CussCrosshair(float width, float height) {
+static void FO_CussCrosshair(float width, float height) {
     const float conc_fps = 144;
     // Limit the rendering speed to reduce blur
     static float next_update;
@@ -561,39 +563,42 @@ void FO_CussCrosshair(float width, float height) {
     next_update = time + 1.0/conc_fps;
 
     if (!IsConced()) {
-        if (cuss_state.cussed) {
+        if (cuss_state.cussed || CVARF(cl_crossx) != 0 ||
+                CVARF(cl_crossy) != CVARF(fo_crossy)) {
             // Make sure we restore crosshairs
-            localcmd(sprintf("cl_crossx %d; cl_crossy %d;\n",
-                        cuss_state.old_x, cuss_state.old_y));
+            localcmd(sprintf("cl_crossx %d; cl_crossy %d;\n", 0, CVARF(fo_crossy)));
+            CVARF(cl_crossx) = 0;
+            CVARF(cl_crossy) = CVARF(fo_crossy);
             cuss_state.cussed = FALSE;
         }
         return;
     }
 
-    if (!cuss_state.cussed) {
-        /* cuss_state.old_x = CVARF(cl_crossx); */
-        /* cuss_state.old_y = CVARF(cl_crossy); */
-        cuss_state.old_x = 0; // TODO: properly save and restore these
-        cuss_state.old_y = 0;
-        cuss_state.cussed = TRUE;
-    }
-
+    cuss_state.cussed = TRUE;
     makevectors(input_angles);  // updated by input_frame
-    vector p = project(pmove_org + 8000 * v_forward);
+    vector p = project(pmove_org + 8000 * cuss_state.c_forward);
 
     localcmd(sprintf("cl_crossx %d; cl_crossy %d;\n",
-                cuss_state.old_x + p_x - width / 2,
-                cuss_state.old_y + p_y - height / 2));
+                p_x - width / 2, CVARF(fo_crossy) + p_y - height / 2));
 }
 
 void FO_UpdateCuss() {
     if (!IsConced())
         return;
 
-    makevectors(input_angles);
-    input_angles = vectoangles(FO_ConcAim());
-    makevectors(input_angles);
-    input_angles_x *= -1;
+    FO_UpdateConcAim();
+
+    float modify_forward = TRUE;
+
+    if ((!pmove_onground && (fo_config.fo_concuss & FOC_EASY_AIR)) ||
+        (pmove_onground && (fo_config.fo_concuss & FOC_EASY_GROUND)))
+        modify_forward = input_buttons & BUTTON0;
+
+    if (modify_forward) {
+        input_angles = vectoangles(cuss_state.c_forward);
+        input_angles_x *= -1;
+        makevectors(input_angles);
+    }
 }
 
 noref void CSQC_Input_Frame() {

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -263,6 +263,9 @@ void WPP_Status() {
 
     PrintFlagField("Clown mode [clown_flags=%d]\n",
                    fo_config.clown_flags, CLOWN_DESC.length, CLOWN_DESC);
+
+    PrintFlagField("Concs [fo_concuss=%d]\n",
+                   fo_config.fo_concuss, FO_CONC.length, FO_CONC);
 }
 #undef PRINT_CONFIG
 
@@ -1722,12 +1725,10 @@ void WP_UpdateViewModel() {
 }
 
 struct {
-    float old_x, old_y;
     float cussed;
-
     float end_time;
-
-    vector view;
+    vector c_view;
+    vector c_forward;
 } cuss_state;
 
 void PredictConc() {

--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -44,6 +44,8 @@ var struct {
 
     float wp_global_disable;
     float gren_beta_disable;
+
+    float fo_concuss;
 } fo_config;
 
 enumflags {
@@ -119,6 +121,28 @@ inline float PredictEnabled(float flag) {
 };
 
 const float PREDICT_FLAGS_DEFAULT = 0;
+
+enumflags {
+    FOC_ON_DEF,  // apply foc_defaults
+    FOC_ON_NODEF,
+    FOC_AFF_MED,
+    FOC_EASY_AIR,
+    FOC_EASY_GROUND,
+    FOC_DISTANCE,
+    FOC_RED_MED,
+};
+
+const float foc_defaults = FOC_AFF_MED | FOC_EASY_AIR;
+
+string FO_CONC[] = {
+    "on (w/ defaults)",
+    "on (no defaults)",
+    "affects medic",
+    "easy air control",
+    "easy ground control",
+    "distance based",
+    "reduce medic effect",
+};
 
 enumflags {
     CLOWN_FAST_PROJECTILES,

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -399,6 +399,7 @@ void EntUpdate_Config() {
     COMM(Byte, wp_global_disable);
     COMM(Byte, gren_beta_disable);
     COMM(Byte, old_ng_rof);
+    COMM(Short, fo_concuss);
 
 #ifdef SSQC
     return TRUE;
@@ -589,6 +590,7 @@ void Predict_InitDefaultConfig() {
     fo_config.wp_default_min_ping_ms = 25;
     fo_config.clown_flags = 0;
     fo_config.clown_grav = 400;
+    fo_config.fo_concuss = 0;
 }
 
 #ifdef SSQC
@@ -655,8 +657,12 @@ static void WeaponPred_CheckConfigUpdate() {
     if (!read_rof_once) {
         if (!fo_config.old_ng_rof)  // Don't overwrite huetf setting this.
             CONFIG_UPDATE(FALSE, "ongrof", old_ng_rof);
-        printf("reading ROF %d\n", fo_config.old_ng_rof);
         read_rof_once = TRUE;
+    }
+
+    if (fo_concuss != fo_config.fo_concuss) {
+        fo_config.fo_concuss = fo_concuss;
+        update = TRUE;
     }
 
     CONFIG_UPDATE(TRUE,  "rewind", rewind_flags);

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -573,6 +573,8 @@ void () DecodeLevelParms = {
 
         // aim based concussion grenade effect
         fo_concuss = CF_GetSetting("foc", "fo_cuss", "0");
+        if (fo_concuss & FOC_ON_DEF)
+            fo_concuss |= foc_defaults;
 
         // Tie some of these other options together for convenience / other
         if (fo_concuss & FOC_DISTANCE)

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -650,12 +650,6 @@ float engineer_move;
 
 float fo_projectiles;
 
-enumflags {
-    FOC_ON,
-    FOC_DISTANCE,
-    FOC_AFF_MED,
-    FOC_RED_MED,
-};
 float fo_concuss;
 
 float numlocs;

--- a/ssqc/scout.qc
+++ b/ssqc/scout.qc
@@ -845,7 +845,7 @@ void (entity inflictor, entity attacker, float bounce,
                             speedbump.owner = head;
                         }
 
-                        if (fo_concuss & FOC_ON) {
+                        if (fo_concuss) {
                             UpdateClientConcussion(head, actual_cuss_time);
 
                             head = head.chain;


### PR DESCRIPTION
Air control with the new conc was harder due to the way it was perturbing forward (and strafe moves perpendicular from this).  A nice compromise is that we only need to perturb the vector while firing; this might look a little weird while spectating (we can improve this later) but we can only apply the effect while firing, which allows regular air control while conc jumping (and not firing).

Setting fo_concuss 1 will now enable the following defaults:
  air control, affects medic

Also add more aggressive resets to make sure we clear crosshair when not conced, add `fo_crossy` for people who want to set cl_crossy now that we're overriding it.