### PR TITLE
weapon pred: use input_movevalues instead of cl_forwardspeed et al

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -603,6 +603,8 @@ void FO_ApplyCussInput() {
     }
 }
 
+void FO_ApplyMaxSpeed();
+
 noref void CSQC_Input_Frame() {
     Sync_GameState();
 
@@ -621,6 +623,7 @@ noref void CSQC_Input_Frame() {
     if (prev_zoomed_in != zoomed_in)
         setsensitivityscaler(zoomed_in ? 1/3 : 1);
 
+    FO_ApplyMaxSpeed();
     FO_ApplyCussInput();
 }
 

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1051,47 +1051,15 @@ void WPP_Dump() {
 
 void WP_Attack();
 
-DEFCVAR_FLOAT(cl_forwardspeed, 0);
-DEFCVAR_FLOAT(cl_backspeed, 0);
-DEFCVAR_FLOAT(cl_sidespeed, 0);
-
-void MP_SetSpeed() {
-    if (!CVARF(wpp_setspeed))
+void FO_ApplyMaxSpeed() {
+    if (!WP_Enabled() || !CVARF(wpp_setspeed) || !RewindFlagEnabled(REWIND_SETSPEED))
         return;
 
-    static float last_playerclass, last_set;
+    if (pstate_pred.tfstate & TFSTATE_AIMING == 0)
+        return;
 
-    float speed = pstate_pred.csqc_maxspeed;
-
-    if (pstate_pred.playerclass != last_playerclass)
-        last_set = -1;  // Force update.
-    last_playerclass = pstate_pred.playerclass;
-
-    const float speed_aiming = 80;
-    const float speed_aiming2dir = ceil(speed_aiming/sqrt(2));
-
-    if (pstate_pred.tfstate & TFSTATE_AIMING) {
-        speed = min(pstate_pred.csqc_maxspeed, speed_aiming);
-
-        // Cap as maxspeed would, but client-side, when enabled.
-        if (RewindFlagEnabled(REWIND_SETSPEED))
-            if (input_movevalues.x && input_movevalues.y)
-                speed = min(speed, speed_aiming2dir);
-    }
-
-    float fastest =
-        max(CVARF(cl_forwardspeed), CVARF(cl_backspeed), CVARF(cl_sidespeed));
-
-    // We check >speed, not =speed as it's still valid for clients to control to
-    // lower speeds.  Except for transitions where the maxspeed is reset.
-    if (speed > last_set || fastest > speed) {
-        last_set = speed;
-
-        string spd = ftos(speed);
-        localcmd("cl_forwardspeed ", spd, "; cl_backspeed ",spd, "; cl_sidespeed ", spd, "\n");
-    }
+    input_movevalues = normalize(input_movevalues) * 80;
 }
-
 
 DEFCVAR_FLOAT(cl_crossx, 0);
 
@@ -1128,7 +1096,6 @@ void WP_Frame() {
         WP_Attack();
 
     WP_Sniper_UpdateSight();
-    MP_SetSpeed();
 }
 
 


### PR DESCRIPTION
Beyond being much cleaner in terms of application and reversion, the instant response means that the values aren't pushed to the next input frame resulting in behavior that appears equivalent to server specified maxspeed.

Neither will generate skips from any directional strafing alone.

It's possible in both cases to generate skips (from legitimately going too fast) from the extra acceleration you can generate from viewangles, but you're just legitimately going too fast in both cases, behavior is the same).