### PR TITLE
conc: massive cleanup

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1744,22 +1744,15 @@ void PredictConc() {
     if (pstate_server.tfstate & TFSTATE_CONC == 0)
         return;
 
-    static float last_conc_finished, last_conc_printed = TRUE;
+    static float last_conc_finished;
     if (pstate_server.conc_finished != last_conc_finished) {
         // New conc, use a single fixed local finish time.
         last_conc_finished = pstate_server.conc_finished;
         cuss_state.end_time = pstate_server.conc_finished - server_time_dt();
-        last_conc_printed = FALSE;
     }
 
-    if (time > cuss_state.end_time) {
+    if (time > cuss_state.end_time)
         pstate_pred.tfstate &= ~TFSTATE_CONC;
-
-        if (!last_conc_printed) {
-            print("Your head feels better now\n");
-            last_conc_printed = TRUE;
-        }
-    }
 }
 
 float WP_ClientThink() {

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -563,7 +563,7 @@ void () DecodeLevelParms = {
         classtips = CF_GetSetting("ct", "classtips", "on");
 
         // concussion grenade effect time [19]
-        cussgrentime = CF_GetSetting("cgt", "cussgrentime", "19");
+        cussgrentime = CF_GetSetting("cgt", "cussgrentime", "10");
 
         // concussion grenade effect time proportional to distance from explosion
         distance_based_cuss_duration = CF_GetSetting("dbcd", "distance_based_cuss_duration", "off");
@@ -572,7 +572,7 @@ void () DecodeLevelParms = {
         medicnocuss = CF_GetSetting("mnc", "medicnocuss", "on");
 
         // aim based concussion grenade effect
-        fo_concuss = CF_GetSetting("foc", "fo_cuss", "0");
+        fo_concuss = CF_GetSetting("foc", "fo_concuss", "0");
         if (fo_concuss & FOC_ON_DEF)
             fo_concuss |= foc_defaults;
 
@@ -2498,6 +2498,23 @@ void () PlayerDeathThink = {
 
 void player_asscan_down1();
 
+enum ConcMode {
+    CONC_IDLESCALE,
+    CONC_CLASSIC,
+    CONC_AIM,
+};
+
+ConcMode GetConcMode() {
+    if (old_grens)
+        return CONC_IDLESCALE;
+    else if (fo_concuss)
+        return CONC_AIM;
+    else
+        return CONC_CLASSIC;
+}
+
+entity FindConcTimer(entity player);
+
 void () PlayerJump = {
     local entity te;
     local float stumble;
@@ -2548,22 +2565,15 @@ void () PlayerJump = {
         StopAssCan();
     }
 
-    if (old_grens != 1) {
-        te = find(world, classname, "timer");
-        while (((te.owner != self) || (te.think != ConcussionGrenadeTimer))
-               && (te != world))
-            te = find(te, classname, "timer");
-
-        if ((te != world) && (te != self)) {
-            crandom();
-            stumble = crandom() * (te.health / 100);
-            if (crandom() < 0) {
-                self.velocity_x = self.velocity_y + stumble;
-                self.velocity_y = self.velocity_x + stumble;
-            } else {
-                self.velocity_x = (-1 * self.velocity_y) + stumble;
-                self.velocity_y = (-1 * self.velocity_x) + stumble;
-            }
+    if (GetConcMode() == CONC_CLASSIC && (self.tfstate & TFSTATE_CONC)) {
+        entity te = FindConcTimer(self);
+        stumble = crandom() * (te.health / 100);
+        if (crandom() < 0) {
+            self.velocity_x = self.velocity_y + stumble;
+            self.velocity_y = self.velocity_x + stumble;
+        } else {
+            self.velocity_x = (-1 * self.velocity_y) + stumble;
+            self.velocity_y = (-1 * self.velocity_x) + stumble;
         }
     }
 };

--- a/ssqc/scout.qc
+++ b/ssqc/scout.qc
@@ -18,6 +18,46 @@ void (entity inflictor, entity attacker, float bounce,
 entity(entity scanner, float scanrange, float enemies,
        float friends) T_RadiusScan;
 
+void ClassicConcussionGrenadeTimer();
+void OldConcussionGrenadeTimer();
+void FoConcussionGrenadeTimer();
+
+void ConcThink() {
+    switch (GetConcMode()) {
+        case CONC_IDLESCALE: return OldConcussionGrenadeTimer();
+        case CONC_CLASSIC: return ClassicConcussionGrenadeTimer();
+        case CONC_AIM: return FoConcussionGrenadeTimer();
+    }
+}
+
+entity FindConcTimer(entity player) {
+    int count;
+    entity* timers = find_list(classname, "timer", EV_STRING, count);
+
+    for (int i = 0; i < count; i++)
+        if (timers[i].owner == player && timers[i].think == ConcThink)
+            return timers[i];
+
+    return __NULL__;
+}
+
+void RemoveConc(entity player, float remove_timer = TRUE) {
+    if (player.tfstate & TFSTATE_CONC == 0)
+        return;
+
+    player.tfstate &= ~TFSTATE_CONC;
+    player.conc_finished = 0;
+
+    if (GetConcMode() == CONC_IDLESCALE)
+        stuffcmd(player, "v_idlescale 0\nfov 90\n");
+
+    if (remove_timer) {
+        entity timer = FindConcTimer(player);
+        if (timer != __NULL__)
+            dremove(timer);
+    }
+}
+
 void () CF_Scout_Dash = {
     if (self.playerclass != PC_SCOUT)
         return;
@@ -418,54 +458,50 @@ void () OldConcussionGrenadeTimer = {
     stuffcmd(self.owner, st);
     stuffcmd(self.owner, "\n");
     if (self.health == 0) {
-        self.tfstate &= ~TFSTATE_CONC;
+        RemoveConc(self.owner, FALSE);
         dremove(self);
     }
 };
 
-void () ConcussionGrenadeTimer = {
+static void SpawnBubble(vector origin) {
+    newmis = spawn();
+    FO_SetModel(newmis, "progs/s_bubble.spr");
+    setorigin(newmis, origin);
+    newmis.movetype = MOVETYPE_NOCLIP;
+    newmis.solid = SOLID_NOT;
+    newmis.velocity = '0 0 15';
+    newmis.nextthink = time + 0.5;
+    newmis.think = bubble_bob;
+    newmis.touch = bubble_remove;
+    newmis.classname = "bubble";
+    newmis.frame = 0;
+    newmis.cnt = 0;
+    setsize(newmis, '-8 -8 -8', '8 8 8');
+}
+
+void () ClassicConcussionGrenadeTimer = {
     local vector src;
     local float pos;
-    local float concadjust;
     local float stumble;
 
     if (self.owner.invincible_finished > time) {
         sprint(self.owner, PRINT_HIGH, "Your head feels better now\n");
-        self.owner.fixangle = 0;
-        self.owner.tfstate &= ~TFSTATE_CONC;
+        RemoveConc(self.owner, FALSE);
         dremove(self);
         return;
     }
 
-    if ((self.health == 200) || (self.health == 400) ||
-        (self.health == 600)
-        || (self.health == 800) || (self.health == 1000)) {
-        newmis = spawn();
-        FO_SetModel(newmis, "progs/s_bubble.spr");
-        setorigin(newmis, self.owner.origin);
-        newmis.movetype = MOVETYPE_NOCLIP;
-        newmis.solid = SOLID_NOT;
-        newmis.velocity = '0 0 15';
-        newmis.nextthink = time + 0.5;
-        newmis.think = bubble_bob;
-        newmis.touch = bubble_remove;
-        newmis.classname = "bubble";
-        newmis.frame = 0;
-        newmis.cnt = 0;
-        setsize(newmis, '-8 -8 -8', '8 8 8');
-    }
+    if (self.health > 0 && self.health % 200 == 0)
+        SpawnBubble(self.owner.origin);
+
     self.health = self.health - 10;
-    if (self.owner.playerclass == 5)
+    if (self.owner.playerclass == PC_MEDIC)
         self.health = self.health - 10;
 
     if (self.health < 0)
         self.health = 0;
 
-    concadjust = 1;
-    self.nextthink = time + 0.25 * concadjust;
-
-    if (concadjust > 1)
-        self.health = self.health - concadjust;
+    self.nextthink = time + 0.25;
 
     pos = pointcontents(self.owner.origin);
     src_x = self.owner.origin_x + self.owner.maxs_x + 2;
@@ -496,10 +532,25 @@ void () ConcussionGrenadeTimer = {
     }
     if (self.health <= 0) {
         sprint(self.owner, PRINT_HIGH, "Your head feels better now\n");
-        self.owner.tfstate &= ~TFSTATE_CONC;
+        RemoveConc(self.owner, FALSE);
         dremove(self);
     }
 };
+
+void FoConcussionGrenadeTimer() {
+    const float bubble_int = 1;
+    float finished = self.owner.conc_finished;
+
+    self.nextthink = min(time + bubble_int, finished);
+
+    if (time < finished) {
+        SpawnBubble(self.owner.origin);
+    } else {
+        sprint(self.owner, PRINT_HIGH, "Your head feels better now\n");
+        RemoveConc(self.owner, FALSE);
+        dremove(self);
+    }
+}
 
 void () ScannerSwitch = {
     local entity te;
@@ -780,7 +831,7 @@ void (entity inflictor, entity attacker, float bounce,
 void (entity inflictor, entity attacker, float bounce,
       entity ignore) T_RadiusBounce = {
     local float actual_cuss_time = cussgrentime;
-    local float distance;    
+    local float distance;
     local float points;
     local entity head;
     local entity te;
@@ -834,8 +885,6 @@ void (entity inflictor, entity attacker, float bounce,
                             }
                         }
 
-                        head.tfstate |= TFSTATE_CONC;
-
                         if (distance_based_cuss_duration
                             && ((head.playerclass == PC_MEDIC) || (head.playerclass == PC_SCOUT))) {
                             entity speedbump;
@@ -845,28 +894,15 @@ void (entity inflictor, entity attacker, float bounce,
                             speedbump.owner = head;
                         }
 
-                        if (fo_concuss) {
+                        head.tfstate |= TFSTATE_CONC;
+                        if (fo_concuss)
                             UpdateClientConcussion(head, actual_cuss_time);
+                        else  // not used currently, but populate anyway
+                            head.conc_finished = time + actual_cuss_time;
 
-                            head = head.chain;
-                            continue;
-                        }
-
-                        te = find(world, classname, "timer");
-                        if (old_grens == TRUE)
-                            while (((te.owner != head) ||
-                                    (te.think !=
-                                     OldConcussionGrenadeTimer))
-                                   && (te != world))
-                                te = find(te, classname, "timer");
-                        else
-                            while (((te.owner != head) ||
-                                    (te.think != ConcussionGrenadeTimer))
-                                   && (te != world))
-                                te = find(te, classname, "timer");
-
+                        entity te = FindConcTimer(head);
                         if (te != world) {
-                            if (old_grens == TRUE) {
+                            if (GetConcMode() == CONC_IDLESCALE) {
                                 stuffcmd(head, "v_idlescale 100\n");
                                 stuffcmd(head, "fov 130\n");
                                 te.health = 100;
@@ -877,13 +913,13 @@ void (entity inflictor, entity attacker, float bounce,
                             }
                         } else {
                             // LogEventAffliction(attacker, head, TFSTATE_CONCUSSED);
-                            if (old_grens == TRUE) {
+                            if (GetConcMode() == CONC_IDLESCALE) {
                                 stuffcmd(head, "v_idlescale 100\n");
                                 stuffcmd(head, "fov 130\n");
                                 stuffcmd(head, "bf\n");
                                 te = spawn();
                                 te.nextthink = time + 5;
-                                te.think = OldConcussionGrenadeTimer;
+                                te.think = ConcThink;
                                 te.team_no = attacker.team_no;
                                 te.classname = "timer";
                                 te.owner = head;
@@ -891,7 +927,7 @@ void (entity inflictor, entity attacker, float bounce,
                             } else {
                                 te = spawn();
                                 te.nextthink = time + 0.25;
-                                te.think = ConcussionGrenadeTimer;
+                                te.think = ConcThink;
                                 te.team_no = attacker.team_no;
                                 te.classname = "timer";
                                 te.owner = head;

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -2255,8 +2255,8 @@ void () TeamFortress_RemoveTimers = {
     local entity te;
 
     self.leg_damage = 0;
-    self.tfstate &= ~TFSTATE_CONC;
     self.is_undercover = 0;
+    RemoveConc(self);
 
     if (self.is_building && engineer_move) {
         TeamFortress_EngineerBuildStop();
@@ -2328,7 +2328,6 @@ void () TeamFortress_RemoveTimers = {
         }
     }
     if (old_grens == 1) {
-        stuffcmd(self, "v_idlescale 0\n");
         stuffcmd(self, "v_cshift; wait; bf\n");
         self.FlashTime = 0;
     }

--- a/ssqc/tfortmap.qc
+++ b/ssqc/tfortmap.qc
@@ -973,13 +973,7 @@ void (entity Goal, entity Player, entity AP, float addb) Apply_Results = {
 
                         te = find(Player, classname, "timer");
 
-                        if (te.think == ConcussionGrenadeTimer || te.think == OldConcussionGrenadeTimer) {
-                            if (old_grens == TRUE) {
-                                stuffcmd(Player, "v_idlescale 0\nfov 90\n");
-                            }
-                            dremove(te);
-                        }
-                        Player.tfstate &= ~TFSTATE_CONC;
+                        RemoveConc(Player);
 
                         if (Player.tfstate & TFSTATE_HALLUCINATING) {
                             if (te.think == HallucinationTimer) {

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -7,9 +7,6 @@ void (vector org, float damage) SpawnBlood;
 
 void () SuperDamageSound;
 
-void () ConcussionGrenadeTimer;
-void () OldConcussionGrenadeTimer;
-
 void (Slot slot) W_ChangeWeaponSlot;
 void () W_ChangeToBestWeapon;
 void () W_PrintWeaponMessage;
@@ -392,6 +389,9 @@ int () W_FireSpanner = {
     }
 };
 
+void RemoveConc(entity player, float remove_timer = TRUE);
+entity FindConcTimer(entity player);
+
 int () W_FireMedikit = {
     local vector source;
     local vector org;
@@ -414,29 +414,19 @@ int () W_FireMedikit = {
                  (self.team_no != 0)) || coop) {
 
                 healam = 200;
-                te = find(world, classname, "timer");
-                while (((te.owner != trace_ent)
-                        || ((te.think != ConcussionGrenadeTimer)
-                            && (te.think != OldConcussionGrenadeTimer)))
-                       && (te != world))
-                    te = find(te, classname, "timer");
-
-                if (te != world) {
-
-                    if (old_grens == TRUE)
-                        stuffcmd(trace_ent, "v_idlescale 0\nfov 90\n");
-
+                if (trace_ent.tfstate & TFSTATE_CONC) {
                     SpawnBlood(org, 20);
 
                     bprint(PRINT_MEDIUM, self.netname, " cured ",
                            trace_ent.netname, "'s concussion\n");
 
+                    entity te = FindConcTimer(trace_ent);
                     if (te.team_no != self.team_no)
                         TF_AddFrags(self, 1);
 
-                    trace_ent.tfstate &= ~TFSTATE_CONC;
-                    dremove(te);
+                    RemoveConc(trace_ent);
                 }
+
                 if (trace_ent.tfstate & TFSTATE_HALLUCINATING) {
 
                     te = find(world, classname, "timer");


### PR DESCRIPTION
Now that we have so many implementations floating around, all of the state around how we heal, do timers, clear on cap, etc is a giant mess.  Even figuring out what the conc type is requires a multi-way eval.

Refactor all of this so it goes through a few common functions.

All so we can have bubbles on the new conc.  The long form name enable name is also now fixed to be `fo_concuss`.