### PR TITLE
mp: remove stuffs

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1055,10 +1055,8 @@ void FO_ApplyMaxSpeed() {
     if (!WP_Enabled() || !CVARF(wpp_setspeed) || !RewindFlagEnabled(REWIND_SETSPEED))
         return;
 
-    if (pstate_pred.tfstate & TFSTATE_AIMING == 0)
-        return;
-
-    input_movevalues = normalize(input_movevalues) * 80;
+    if (pstate_pred.tfstate & TFSTATE_AIMING)
+        input_movevalues = normalize(input_movevalues) * 80;
 }
 
 DEFCVAR_FLOAT(cl_crossx, 0);

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -1258,7 +1258,7 @@ void (entity p) TeamFortress_SetSpeed = {
         // Typically this hits spectators and then spec movetype --> maxspeed
         // actually ignored.
         p.maxspeed = 0;
-        stuffcmd(p, "cl_backspeed 500; cl_forwardspeed 500; cl_sidespeed 500\n");
+        stuffcmd(p, "cl_movespeedkey 1;cl_backspeed 500; cl_forwardspeed 500; cl_sidespeed 500;\n");
         return;
     }
 
@@ -1292,14 +1292,12 @@ void (entity p) TeamFortress_SetSpeed = {
     if (!RewindFlagEnabled(REWIND_SETSPEED) || !client_enable) {
         if (p.tfstate & TFSTATE_AIMING)
             new_max = min(new_max, 80);
-
-        sp = ftos(new_max);
-        stuffcmd(p, "cl_backspeed ", sp, "; cl_forwardspeed ", sp,
-                 "; cl_sidespeed ", sp, "\n");
     }
 
     p.maxspeed = new_max;
-    p.csqc_maxspeed = new_max;  // Always set, need populated on transition.
+    p.csqc_maxspeed = new_max;  // Note: with new input_movevalues construction
+                                // this isn't technically needed until we do
+                                // something like client-side tranq pred.
 };
 
 void () TeamFortress_SetHealth = {


### PR DESCRIPTION
We really don't need to do much with client movespeeds anymore, our maxspeed handling does the work.  Remove some stuffs for legacy clients that could have led to sticky speeds; we now only stuff reasonable (fast) defaults to a spec.