### PR TITLE
experimental: tune new conc

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -512,30 +512,64 @@ static float IsFoConced() {
     return pstate_pred.tfstate & TFSTATE_CONC;
 }
 
+struct ConcCurve {
+    float duration;
+    float cycles;
+    float amp_end;
+    float offset;
+};
 
-static float BlendAmp(float start, float end, float rem, float D) {
+ConcCurve conc_curve[] = {
+    {1, 0.5, 0.0, 0.5},
+    {6, 4, 0.2, 0.5},
+    {2, 1.5, 0.75},
+    {1, 1, 1},
+    {0, 0, 1},  // Terminator
+};
+
+ConcCurve clown_curve[] = {
+    {10, 4, 0.75},
+    {0, 0, 0.75},  // Terminator
+};
+
+float ClownConcPeriod() { return clown_curve[0].duration; }
+
+static float Blend(float start, float end, float rem, float D) {
     return rem/D * start + (D-rem)/D * end;
 }
 
 static vector FO_Conc_Offset() {
-    const float P = 4;
-
+    static float last_rem;
     float rem = cuss_state.end_time - time;
     if (rem < 0)
         return '0 0 0';
 
-    float a = ((rem % P) / P) * 2 * M_PI;
+    ConcCurve* table;
+    float len;
+    ConcCurve* cur = __NULL__;
+    float i, rot = 0;
 
-    float amp = pstate_pred.conc_amp;
-    if (rem >= 8)
-        amp *= 1;
-    else if (rem >= 2)
-        amp *= BlendAmp(1.0, 0.5, rem - 2, 8 - 2);
-    else
-        amp *= BlendAmp(0.5, 0, rem, 2);
+    if (!IsClownMode(CLOWN_CONC)) {
+            table = conc_curve;
+            len = conc_curve.length;
+    } else {
+            table = clown_curve;
+            len = clown_curve.length;
+    }
 
-    float x = amp * sin(a), y = amp * sin(a) * cos(a);
-    return [x, y, 0];
+    for (i = 0; i < len - 1; i++) {
+        cur = &table[i];
+        if (rem <= cur->duration)
+            break;
+        rem -= cur->duration;
+    }
+
+    float amp = Blend(table[i+1].amp_end, cur->amp_end, rem, cur->duration);
+    amp *= pstate_pred.conc_amp;
+    float a = (cur->duration - rem) / cur->duration * cur->cycles * 2 * M_PI;
+    a += cur->offset * 2 * M_PI;
+
+    return [amp * sin(a), amp * sin(a) * cos(a), 0];
 }
 
 static void FO_UpdateConcAim() {

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1726,12 +1726,16 @@ struct {
     float end_time;
     vector c_view;
     vector c_forward;
+
+    float last_a;
 } cuss_state;
+
+float ClownConcPeriod();
 
 void PredictConc() {
     if (IsClownMode(CLOWN_CONC)) {
-        if (cuss_state.end_time < time + 6)
-            cuss_state.end_time += 4;  // Must align with period.
+        if (cuss_state.end_time < time)
+            cuss_state.end_time = time + ClownConcPeriod();
 
         pstate_pred.conc_amp = 100;
         pstate_pred.tfstate |= TFSTATE_CONC;
@@ -1749,6 +1753,7 @@ void PredictConc() {
         // New conc, use a single fixed local finish time.
         last_conc_finished = pstate_server.conc_finished;
         cuss_state.end_time = pstate_server.conc_finished - server_time_dt();
+        cuss_state.last_a = 0;
     }
 
     if (time > cuss_state.end_time)

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -652,17 +652,17 @@ static void WeaponPred_CheckConfigUpdate() {
     CONFIG_UPDATE(FALSE, "wpgd", wp_global_disable);
     CONFIG_UPDATE(FALSE, "gbd", gren_beta_disable);
 
+    if (fo_concuss != fo_config.fo_concuss) {
+        fo_config.fo_concuss = fo_concuss;
+        update = TRUE;
+    }
+
     // Not dynamically updatable.
     static float read_rof_once = FALSE;
     if (!read_rof_once) {
         if (!fo_config.old_ng_rof)  // Don't overwrite huetf setting this.
             CONFIG_UPDATE(FALSE, "ongrof", old_ng_rof);
         read_rof_once = TRUE;
-    }
-
-    if (fo_concuss != fo_config.fo_concuss) {
-        fo_config.fo_concuss = fo_concuss;
-        update = TRUE;
     }
 
     CONFIG_UPDATE(TRUE,  "rewind", rewind_flags);

--- a/ssqc/scout.qc
+++ b/ssqc/scout.qc
@@ -828,6 +828,57 @@ void (entity inflictor, entity attacker, float bounce,
     }
 };
 
+
+struct ClassConc {
+    float amp_mult;
+    float duration_mult;
+};
+
+static ClassConc class_mod[] = {
+    {  1.0, 1.0  },  // observer
+    {  1.5, 1.0  },  // scout
+    {  1.0, 1.0  },  // sniper
+    {  1.0, 1.0  },  // soldier
+    {  1.0, 1.0  },  // demoman
+    {  1.0, 0.5  },  // medic
+    {  0.75, 1.0  },  // hwguy
+    {  1.0, 1.0  },  // pyro
+    {  1.0, 1.0  },  // spy
+    {  1.0, 1.0  },  // engineer
+    {  1.0, 1.0  },  // randompc
+    {  1.0, 1.0  },  // civilian
+};
+
+static ClassConc get_class_mod(float playerclass) {
+    string short_a = sprintf("foc_a%d", playerclass);
+    string long_a = sprintf("fo_concuss_amp%d", playerclass);
+    string short_d = sprintf("foc_d%d", playerclass);
+    string long_d = sprintf("fo_concuss_dur%d", playerclass);
+
+    ClassConc r = class_mod[playerclass];
+
+    float amp_m = CF_GetSetting(short_a, long_a, "off");
+    if (amp_m)
+        r.amp_mult = amp_m;
+
+    float dur = CF_GetSetting(short_d, long_d, "off");
+    if (dur)
+        r.duration_mult = dur;
+
+    return r;
+}
+
+static void UpdateClientConcussion(entity player, float duration) {
+    float base_amp = CF_GetSetting("foca", "foc_amp", "110");
+
+    // Once non debug, these should be once per map.
+    ClassConc r = get_class_mod(player.playerclass);
+
+    // networked via prediction ent
+    player.conc_amp = base_amp * r.amp_mult;
+    player.conc_finished = time + duration * r.duration_mult;
+}
+
 void (entity inflictor, entity attacker, float bounce,
       entity ignore) T_RadiusBounce = {
     local float actual_cuss_time = cussgrentime;

--- a/ssqc/status.qc
+++ b/ssqc/status.qc
@@ -614,35 +614,6 @@ void (entity Player) InitAllStatuses = {
     }
 };
 
-void UpdateClientConcussion(entity player, float duration) {
-    msg_entity = player;
-
-    static float scout_mult;
-    static float medic_mult;
-    static float heavy_mult;
-    float amp = 100;
-
-    // Once non debug, these should be once per map.
-    amp = CF_GetSetting("foca", "fo_cuss_amp", "100");
-    scout_mult = CF_GetSetting("focs", "fo_cuss_scout", "1.5");
-    medic_mult = CF_GetSetting("focm", "fo_cuss_medic", "0.5");
-    heavy_mult = CF_GetSetting("foch", "fo_cuss_heavy", "0.25");
-
-    if (player.playerclass == PC_HVYWEAP) {
-        amp *= heavy_mult;
-    } else if (player.playerclass == PC_SCOUT) {
-        amp *= scout_mult;
-    } else if (player.playerclass == PC_MEDIC) {
-        if (fo_concuss & FOC_RED_MED)
-            duration /= 2;
-        amp *= medic_mult;
-    }
-
-    // networked via prediction ent
-    player.conc_amp = amp;
-    player.conc_finished = time + duration;
-}
-
 float laststate;
 void (entity Player, entity Goal) UpdateClientButtonStatus = {
     if(!infokeyf(Player, INFOKEY_P_CSQCACTIVE))


### PR DESCRIPTION
- Some Brazilian feedback is that it still felt a little too easy to hit right after conc affect so do some things to make the curve more parameterizable. Particularly, reducing the period of initial rotations (to accelerate how fast aim is moving) for the first few seconds before falling off.
- Slightly increase base amplitude, period is no longer fixed per above
- Remove sync on now redundant period
- Reduce effect for medic by default
- Increase effect for heavy by default
- More run-time tunables to shape the curve a