### PR TITLE
Prevent server crashing when reloadnext issued without playerclass

### DIFF
--- a/ssqc/actions.qc
+++ b/ssqc/actions.qc
@@ -469,6 +469,9 @@ void (entity pe_player, float f_type) CF_Identify = {
 };
 
 void () TeamFortress_ReloadNext = {
+    if (self.playerclass < 1 || self.playerclass > 9)
+        return;
+
     Slot slot = self.current_slot;
 
     do {


### PR DESCRIPTION
Looks like Player entered the game and issued a `reloadnext` without a class, crashing server.
```
stagingserver_1  | 2023-05-01T10:04:37.458118664Z Player entered the game
 @@ hydr0 building sentry gun @ someplace @@2055Z (@B@.hydr0.bud$.):
stagingserver_1  | 2023-05-01T10:04:40.270545081Z [5] minutes remaining
stagingserver_1  | 2023-05-01T10:04:43.866382217Z zenon played catch with Sakunera's grenade
stagingserver_1  | 2023-05-01T10:04:45.353322825Z NEWBY got too close to his own grenade
stagingserver_1  | 2023-05-01T10:04:54.509534859Z zenon played catch with Sakunera's grenade
stagingserver_1  | 2023-05-01T10:04:55.511904046Z @B@.RedfoX. is mown down by @B@.hydr0.bud$.'s sentry gun
stagingserver_1  | 2023-05-01T10:04:57.391470630Z @B@.wm. played catch with Mortal's grenade
stagingserver_1  | 2023-05-01T10:04:57.617988391Z Twi- gets spammed by NEWBY's Mirv grenade
stagingserver_1  | 2023-05-01T10:05:00.774063672Z Ummm, Sakunera, you're supposed to THROW the grenade!
stagingserver_1  | 2023-05-01T10:05:00.878560660Z Sakunera sat on his own grenade
stagingserver_1  | 2023-05-01T10:05:01.804971981Z @B@.hydr0.bud$.'s sentrygun was destroyed by Mortal
stagingserver_1  | 2023-05-01T10:05:05.832651970Z @B@.wm. got to know his grenade too well
stagingserver_1  | 2023-05-01T10:05:08.333323768Z Mortal was gibbed by zenon's rocket
stagingserver_1  | 2023-05-01T10:05:10.312507138Z Twi- gets sawn in half by NEWBY
 @@ hydr0 building sentry gun @ someplace @@2203Z (@B@.hydr0.bud$.):
stagingserver_1  | 2023-05-01T10:05:21.064254055Z unknown-file : MakeSlot
stagingserver_1  | 2023-05-01T10:05:21.068807619Z     arg0(8973): 4===1082130432
stagingserver_1  | 2023-05-01T10:05:21.068815275Z      unk(8974): 5.60519e-45===4
stagingserver_1  | 2023-05-01T10:05:21.068820137Z unknown-file : FO_FindPrevNextWeaponSlot
stagingserver_1  | 2023-05-01T10:05:21.068824512Z unknown-file : TeamFortress_ReloadNext
stagingserver_1  | 2023-05-01T10:05:21.069072835Z unknown-file : ImpulseCommands
stagingserver_1  | 2023-05-01T10:05:21.069081349Z unknown-file : W_WeaponFrame
stagingserver_1  | 2023-05-01T10:05:21.069085630Z unknown-file : PlayerPostThink
stagingserver_1  | 2023-05-01T10:05:21.069090014Z
stagingserver_1  | 2023-05-01T10:05:21.071190546Z COM_WriteFile: ssqccore.txt
stagingserver_1  | 2023-05-01T10:05:21.072662004Z SV_Error: runaway loop error
stagingserver_1  | 2023-05-01T10:05:21.074145509Z
stagingserver_1  | 2023-05-01T10:05:21.074151167Z Server ended
stagingserver_1  | 2023-05-01T10:05:21.075162518Z Server recording complete
stagingserver_1  | 2023-05-01T10:05:21.075341007Z /download "demos/2023-05-01-09-49-14_[ff-destroy3]_blue_vs_red.mvd"
stagingserver_1  | 2023-05-01T10:05:21.076654780Z Client "@B@.RedfoX." removed
stagingserver_1  | 2023-05-01T10:05:21.077730198Z Client "Twi-" removed
stagingserver_1  | 2023-05-01T10:05:21.078052089Z Client "NEWBY" removed
stagingserver_1  | 2023-05-01T10:05:21.078379822Z Client "@B@.hydr0.bud$." removed
stagingserver_1  | 2023-05-01T10:05:21.078619952Z Client "@B@.wm." removed
stagingserver_1  | 2023-05-01T10:05:21.078851368Z Client "Mortal" removed
stagingserver_1  | 2023-05-01T10:05:21.079082817Z Client "Sakunera" removed
stagingserver_1  | 2023-05-01T10:05:21.079313234Z Client "zenon" removed
stagingserver_1  | 2023-05-01T10:05:21.079542160Z Client "Player" removed
stagingserver_1  | 2023-05-01T10:05:21.080562321Z qc file data/2023-05-01-09-49-14_[ff-destroy3]_blue_vs_red.json was still open
stagingserver_1  | 2023-05-01T10:05:21.080734513Z COM_WriteFile: data/2023-05-01-09-49-14_[ff-destroy3]_blue_vs_red.json
stagingserver_1  | 2023-05-01T10:05:21.418240686Z Fatal error: SV_Error: runaway loop error
stagingserver_1  | 2023-05-01T10:05:21.418360733Z
stagingserver_1  | 2023-05-01T10:05:21.418450688Z
stagingserver_1  | 2023-05-01T10:05:21.436981056Z Error: signal SIGABRT:
stagingserver_1  | 2023-05-01T10:05:21.437277492Z /lib/x86_64-linux-gnu/libc.so.6(pthread_kill+0x12c)[0x7f5db97e8a7c]
stagingserver_1  | 2023-05-01T10:05:21.437459993Z /lib/x86_64-linux-gnu/libc.so.6(raise+0x16)[0x7f5db9794476]
stagingserver_1  | 2023-05-01T10:05:21.437692329Z /lib/x86_64-linux-gnu/libc.so.6(abort+0xd3)[0x7f5db977a7f3]
stagingserver_1  | 2023-05-01T10:05:21.437846969Z /fortressonesv/fortressone-sv(+0x2d2136)[0x556c0431f136]
stagingserver_1  | 2023-05-01T10:05:21.438027950Z /fortressonesv/fortressone-sv(+0x177650)[0x556c041c4650]
stagingserver_1  | 2023-05-01T10:05:21.438191816Z /fortressonesv/fortressone-sv(+0x2a2d5c)[0x556c042efd5c]
stagingserver_1  | 2023-05-01T10:05:21.438341402Z /fortressonesv/fortressone-sv(+0x2b3af4)[0x556c04300af4]
stagingserver_1  | 2023-05-01T10:05:21.438498135Z /fortressonesv/fortressone-sv(+0x2cf30f)[0x556c0431c30f]
```