### PR TITLE
login: fix file-handle leaks and refactor

### DIFF
--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -2,6 +2,7 @@ void ParseSBAR();
 void ParseGrenPrimed(float grentype, float primed_at, float explodes_at);
 void ParseHitFlag(vector targpos, float mitdmg, float rawdmg, float hitflag);														 
 float StartGrenTimer(float primed_at, float expires_at, float grentype, float play_sound);
+float FoLogin(string token, float print_error);
 
 void() CSQC_Parse_Event = {
     float msgtype = readbyte();
@@ -342,13 +343,8 @@ void() CSQC_Parse_Event = {
             RemoveVoteMap(readstring(), FALSE);
             break;
         case MSG_LOGIN:
-            local float filehandle = fopen(FO_TOKEN_PATH, FILE_READ);
-            if (filehandle != -1) {
-                localcmd("setinfo _fo_token ", fgets(filehandle), "\n");
-                localcmd("cmd fo-login-silent\n");
-            } else {
+            if (!FoLogin("", FALSE))
                 print("You are not logged in\n");
-            }
             break;
         case MSG_PAUSE:
             CsGrenTimer::SyncPause();

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -10,7 +10,7 @@ void AddGrenTimer(float grentype, float offset);
 void StopGrenTimers();
 float IsValidToUseGrenades();
 void Sync_GameState();
-void FoLogin(string token);
+float FoLogin(string token, float print_error);
 void Perf_Status();
 void FO_Hud_Init();
 float InFluid(vector point);
@@ -238,7 +238,7 @@ noref float(string cmd) CSQC_ConsoleCommand = {
             Slot_Keyup(stof(argv(1)));
             break;
         case "login":
-            FoLogin(argv(1));
+            FoLogin(argv(1), TRUE);
             break;
         case "fo_hud_editor":
             FO_Hud_Editor();
@@ -720,25 +720,35 @@ void Sync_GameState() {
     PM_PredictJump();
 }
 
-void FoLogin(string token) {
-    local float filehandle;
+static string FoLogin_GetToken() {
+    float filehandle = fopen(FO_TOKEN_PATH, FILE_READ);
+    if (filehandle == -1)
+        return "";
 
+    string token = fgets(filehandle);
+    fclose(filehandle);
+    return token;
+}
+
+// Doesn't actually return success, just whether it sent a token.
+float FoLogin(string token, float print_error) {
     if (token != "") {
-        filehandle = fopen(FO_TOKEN_PATH, FILE_WRITE);
+        float filehandle = fopen(FO_TOKEN_PATH, FILE_WRITE);
         fputs(filehandle, token);
         fclose(filehandle);
     } else {
-        filehandle = fopen(FO_TOKEN_PATH, FILE_READ);
-        if (filehandle == -1) {
-            print("Can't login without valid token\n");
-            return;
-        } else {
-            token = fgets(filehandle);
-        }
+        token = FoLogin_GetToken();
+    }
+
+    if (token == "") {
+       if (print_error)
+            print("Token required: Please sign-up at FortressOne.org and follow the instructions to generate your login token.\n");
+        return FALSE;
     }
 
     localcmd("setinfo _fo_token ", token, "\n");
     localcmd("cmd fo-login-silent\n");
+    return TRUE;
 }
 
 static string to_precision(float f, float p) {


### PR DESCRIPTION
#The current login code is leaking file handles in two places which leads to login failures when we run out of handles and it's unable to read the token.

Fix this but also just refactor so we're not duplicating the read/send path between client and server initiated.  Add instructions for people who dont have a token to visit the FO website to get one.