### PR TITLE
Prevent joining team without login. This effectively enforces login. …

### DIFF
--- a/ssqc/tforttm.qc
+++ b/ssqc/tforttm.qc
@@ -295,8 +295,8 @@ float (entity pe, float tno, float skipclasscheck) TeamFortress_TeamSet_Options 
 };
 
 float (float tno) TeamFortress_TeamSet = {
-    if (quadmode && !cb_prematch && tno >=1 && tno <=4 && !self.fo_login && fo_login_required) {
-        sprint(self, PRINT_HIGH, "Cannot join game in progress if not logged in. Spectate or see fortressone.org\n");
+    if (quadmode && tno >=1 && tno <=4 && !self.fo_login && fo_login_required) {
+        sprint(self, PRINT_HIGH, "You need to sign in first. Get your login token at www.fortressone.org\n");
         return 0;
     }
 

--- a/ssqc/tforttm.qc
+++ b/ssqc/tforttm.qc
@@ -295,7 +295,7 @@ float (entity pe, float tno, float skipclasscheck) TeamFortress_TeamSet_Options 
 };
 
 float (float tno) TeamFortress_TeamSet = {
-    if (quadmode && tno >=1 && tno <=4 && !self.fo_login && fo_login_required) {
+    if (quadmode && tno >= 1 && tno <= 4 && !self.fo_login && fo_login_required) {
         sprint(self, PRINT_HIGH, "You need to sign in first. Get your login token at www.fortressone.org\n");
         return 0;
     }


### PR DESCRIPTION
…But also prevents random players from joining during prematch, requiring them to be kicked (often repeatedly)