### PR TITLE
client: add slot_a for alternating slot selection

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -118,6 +118,9 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     registercommand("-dropflag");
     registercommand("+rj");
     registercommand("-rj");
+
+    registercommand("slot_a");
+
     // registercommand("+quick1");
     // registercommand("-quick1");
     // registercommand("+quick2");
@@ -227,6 +230,8 @@ void Slot_Keyup(float slot) {
         localcmd("-attack\n");
     }
 }
+
+void W_ChangeToSlotAlternate(string opt1, string opt2);
 
 noref float(string cmd) CSQC_ConsoleCommand = {
     tokenize_console(cmd);
@@ -476,6 +481,9 @@ noref float(string cmd) CSQC_ConsoleCommand = {
             break;
         case "vote_removemap":
             RemoveVoteMap(argv(1), TRUE);
+            break;
+        case "slot_a":  // Alternate between passed options
+            W_ChangeToSlotAlternate(argv(1), argv(2));
             break;
     }
 

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -644,6 +644,23 @@ void WP_ChangeWeapon(Slot slot) {
     // UpdateViewModel will propagate.
 }
 
+// Alternate between opt1/opt2, activating opt1 if neither is active.
+// Useful for demoman to have red/yellows bound to 1 key.
+void W_ChangeToSlotAlternate(string opt1, string opt2) {
+    float v1 = strlen(opt1) > 0 ? stof(opt1) : 0;
+    float v2 = strlen(opt2) > 0 ? stof(opt2) : v1;
+
+    if ((v1 < 1 || v1 > TF_NUM_SLOTS) || (v2 < 1 || v2 > TF_NUM_SLOTS))
+        return;
+
+    // The OWI/slot mess rears its head again here.  We convert to a slot for
+    // comparison but use the naked input value which will then be converted per
+    // OWI if active.
+    Slot slot = FO_SlotByInput(pstate_pred.playerclass, v1);
+    float imp = IsSameSlot(pstate_pred.current_slot, slot) ? v2 : v1;
+    localcmd(sprintf("impulse %d\n", imp));
+}
+
 Slot WP_BestWeaponSlot() {
     for (float i = 1; i <= TF_NUM_SLOTS; i++) {
         Slot slot = MakeSlot(i);

--- a/share/weapons.qc
+++ b/share/weapons.qc
@@ -34,7 +34,8 @@ float SlotIndex(Slot slot) {
         printf("ERROR: OOB slot id (%d) found.  Continuing.\n", (float)slot.id);
         return TF_NUM_SLOTS - 1;
     }
-    return slot.id - 1; }
+    return slot.id - 1; 
+}
 
 // Convert a weapon-bit to a linear index.
 static float WEAP_to_index(float weapon) {


### PR DESCRIPTION
pecan was dependent using bugs in the old +slot implementation so that he could switch between reds/yellows while using a +slot bind.

Add a new client command to do what he really wants:
  to be able to swap between reds/yellows, swapping to reds if neither active

We implement a more generic form of this, "slot_a <slot_a> <slot_b>".  This lets you bind it with 2 passed slots, when activated, it will switch to slot_a if neither is selected, otherwise it will alternate between them.

pecan's use case becomes: bind key slot_a 1 2