### PR TITLE
init: fix missing new line

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -769,7 +769,7 @@ void Perf_Status() {
 }
 
 void ClientSettings_Check() {
-    localcmd("cl_movespeedkey 1");
+    localcmd("cl_movespeedkey 1\n");
     if (cvar("worker_count") == 0)
         printf("ERROR: Please set `worker_count 4` to reduce stuttering!\n");
     if (cvar("r_temporalscenecache") == 0)


### PR DESCRIPTION
The first client_alias bind was being swallowed because there was an partially constructed command in the buffer it was being appended to.