### PR TITLE
wp: restore zero check on r_drawviewmodel

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1738,7 +1738,7 @@ void WP_UpdateViewModel() {
     }
 
     static float no_weap_mask = TFSTATE_NO_WEAPON | TFSTATE_FLASHED;
-    if (pstate_pred.tfstate & no_weap_mask) {
+    if (pstate_pred.tfstate & no_weap_mask || CVARF(r_drawviewmodel) == 0) {
         viewmodel.modelindex = 0;
         return;
     }


### PR DESCRIPTION
This also needs to be put back where it was, otherwise it breaks `r_drawviewmodel 0` to hide the viewmodel.