### PR TITLE
wp: update enable state on player transitions

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -683,7 +683,15 @@ void _Sync_ServerCommandFrame() {
     is_spectator = stof(getplayerkeyvalue(player_localnum, "*spectator"));
     if (is_spectator)
         is_observer = FALSE;
+
+    static float last_is_player;
+
+    last_is_player = is_player;
     is_player = (!is_spectator && !is_observer);
+
+    if (last_is_player != is_player)
+        WP_PlayerTransition();
+
     if (!is_player || getstatf(STAT_HEALTH) <= 0)
         is_alive = 0;
     else

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -296,8 +296,10 @@ void WPP_UpdateEnable(float force) {
         last_fo_predict_projectiles = CVARF(fo_predict_projectiles);
     }
 
+#ifdef 0
     if (avg_ping.samples.count < 5)
         return;  // Skip until we have a useful number of samples.
+#endif
 
     if (!force && time < next_wpp_enable_check)
         return;
@@ -358,6 +360,10 @@ void WPP_UpdateEnable(float force) {
 
     if (pengine.viewmodel != __NULL__)
         WP_UpdateViewModel();
+}
+
+void WP_PlayerTransition() {
+    WPP_UpdateEnable(TRUE);
 }
 
 DEFCVAR_FLOAT(fo_minping_min, 0);    // Can be used to set a lower-bound on


### PR DESCRIPTION
More quickly update enable state on player/state transitions.  Also no longer wait for stable ping since we're transitioning away from ping toggle.