### PR TITLE
spec: fix ident string spam (maybe fix spectate w/ proxy?)

### DIFF
--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -426,8 +426,9 @@ void ParseGrenPrimed(float grentype, float primed_at, float explodes_at) {
     if (primed_at < last_death_time)
         return;
 
-    local float timer_flags = 0;
-    switch (CVARF(fo_grentimer)) {
+    float timer_flags = 0;
+    float timer_mode = is_player ? CVARF(fo_grentimer) : 1;
+    switch (timer_mode) {
         case 0: break;
         case 1: timer_flags = FL_GT_SOUND; break;
         // 2 [and something sane for anything we don't recognize.]

--- a/ssqc/actions.qc
+++ b/ssqc/actions.qc
@@ -261,11 +261,7 @@ void (entity pe_player) FO_Spectator_Identify = {
         pe_player.ident_time = time + 0.5;
         if(pe_player.ident_string != s_id_string) {
             pe_player.ident_string = s_id_string;
-            //if(infokeyf(pe_player, INFOKEY_P_CSQCACTIVE)) {
-                UpdateClientIDString(pe_player);
-            //} else {
-            //    Status_Refresh(pe_player);
-            //}
+            UpdateClientIDString(pe_player);
         }
     }
 }

--- a/ssqc/status.qc
+++ b/ssqc/status.qc
@@ -827,20 +827,18 @@ void UpdateClientPlayerDie(entity pl) = {
 void UpdateClientIDString(entity pl) {
     if(!infokeyf(pl, INFOKEY_P_CSQCACTIVE))
         return;
+
+    string ident = time < pl.ident_time ? pl.ident_string : "";
     // only send updates
-    //if(time < pl.ident_time && pl.ident_string == pl.last_ident_string)
-    //    return;
+    if (ident == pl.last_ident_string)
+        return;
+    pl.last_ident_string = ident;
+
     msg_entity = pl;
-    WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET); 
+    WriteByte(MSG_MULTICAST, SVC_CGAMEPACKET);
     WriteByte(MSG_MULTICAST, MSG_ID);
-    // identify
-    if (pl.ident_string && time < pl.ident_time) {
-        WriteString(MSG_MULTICAST, pl.ident_string);
-    } else {
-        WriteString(MSG_MULTICAST, "");
-    }
+    WriteString(MSG_MULTICAST, ident);
     multicast('0 0 0', MULTICAST_ONE_NOSPECS);
-    pl.last_ident_string = pl.ident_string;
 }
 
 void UpdateClientStatusBar(entity pl)
@@ -1034,6 +1032,8 @@ void (entity pl) RefreshStatusBar = {
     if (height > 300)
         height = 300;
     height = height - pl.StatusStringLines - 13;
+
+    pl.StatusRefreshTime = time + 1.5;
 
     csqcactive = infokeyf(pl, INFOKEY_P_CSQCACTIVE);
     if(pl.classname == "observer" && csqcactive) {
@@ -1285,7 +1285,6 @@ void (entity pl) RefreshStatusBar = {
         }
     }
     centerprint(pl, pl.StatusString, pad, ident, ct, s1, s2, s3);
-    pl.StatusRefreshTime = time + 1.5;
     strunzone(pad); strunzone(ct); strunzone(s1); strunzone(s2); strunzone(s3);
 };
 


### PR DESCRIPTION
Early return when spectator/observer was preventing the last sbar update from being cached, resulting in spectators getting absolutely reamed by messages, in particular ident.  Further improve this by only sending ident updates when there is an actual change, rather than constantly.

This could well explain the proxy overflows we see when spectating.