### PR TITLE
rewind: use rewind positions during physics updates

### DIFF
--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -49,7 +49,8 @@ var struct {
 } fo_config;
 
 enumflags {
-    REWIND_PROJ_HIT,
+    REWIND_PROJ_FIRE,
+    REWIND_PROJ_TRAVEL,
     REWIND_KNOCKBACK,
     REWIND_SETSPEED,
     REWIND_GRENADES,
@@ -58,7 +59,8 @@ enumflags {
 };
 
 string REWIND_DESC[] = {
-    "rewind projectile hit",
+    "rewind projectile on firing",
+    "rewind on projectile travel",
     "rewind pipe knockback",
     "allow csqc to handle maxspeed",
     "rewind grenade throws",
@@ -66,7 +68,8 @@ string REWIND_DESC[] = {
     "open doors earlier for hpbs [requires rfd=1]",
 };
 
-const float REWIND_DEFAULT_FLAGS = REWIND_KNOCKBACK | REWIND_PROJ_HIT |
+const float REWIND_DEFAULT_FLAGS = REWIND_KNOCKBACK | REWIND_PROJ_FIRE |
+                                   REWIND_PROJ_TRAVEL |
                                    REWIND_FORWARD_PROJ_SELFKNOCK |
                                    REWIND_SETSPEED;
 

--- a/share/physics.qc
+++ b/share/physics.qc
@@ -195,7 +195,7 @@ float Phys_Adv_Linear(entity e, float dt, float phys_flags) {
     return dt;
 }
 
-var void(entity e, float step) RewindSyncTime;
+var void(entity e, float target_time) RewindSyncTime;
 
 static void Phys_CapVel(entity e) {
     static const float limit = 32 / phys_tic;
@@ -233,7 +233,7 @@ float Phys_Advance(entity e, float target_time, float phys_flags) {
 
         step = min(phys_tic, delta);
         if (phys_flags & PHYSF_REWIND_PLAYERS)
-            RewindSyncTime(e, step);
+            RewindSyncTime(e, e.phys_time + step/2);
 
         if (IsClownMode(CLOWN_PROJ_GRAVITY))
             e.velocity_z += -fo_config.clown_grav * step;

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -767,9 +767,29 @@ void WeaponPred_DoServerClientThink() {
     }
 }
 
+void ProjRewindForTravel(entity e, float target_time);
+void NoRewindSyncFn(entity e, float target_time);
+void RW_StashAll();
+void RW_RestoreAll();
+
 void FO_CustomPhysics() {
     if (!self.voided) {
-        Phys_Advance(self, time, 0);
+        float physf = 0;
+        if (RewindFlagEnabled(REWIND_PROJ_TRAVEL)) {
+            // This is a little inside out, it would be nice to do this by time
+            // then by projectile/player, but structure makes that difficult
+            // without more aggressive change.
+            RW_StashAll();
+            physf = PHYSF_REWIND_PLAYERS;
+            RewindSyncTime = ProjRewindForTravel;
+        }
+
+        Phys_Advance(self, time, physf);
+
+        if (RewindFlagEnabled(REWIND_PROJ_TRAVEL)) {
+            RewindSyncTime = NoRewindSyncFn;
+            RW_RestoreAll();
+        }
 
         // Moving platforms don't get properly reflected into the entities CSQC
         // sees so just blast the client with updates when on one (in motion).

--- a/ssqc/rewind.qc
+++ b/ssqc/rewind.qc
@@ -274,6 +274,20 @@ class FOPlayer {
     };
 };
 
+// TODO: untangle and decide whether the class stuff is adding any value
+void RW_RewindAll(float when) {
+    FOPlayer::RewindAll(when);
+}
+
+void RW_StashAll() {
+    RL_StashPositions(rewind_players);
+}
+
+void RW_RestoreAll() {
+    FOPlayer::RestoreAll();
+
+}
+
 float (string ps_short, string ps_setting, string ps_default) CF_GetSetting;
 
 float RewindPlayersExceptSelf(float farthest_rewind_point) {
@@ -296,8 +310,16 @@ float RewindPlayersExceptSelf(float farthest_rewind_point) {
     return TRUE;
 }
 
-void ProjRewindForPhys(entity e, float step) {
-    RL_RewindTo(rewind_players, e.owner, e.phys_time + step / 2);
+void ProjRewindForTravel(entity e, float target_time) {
+    RL_RewindTo(rewind_players, world, target_time);
+}
+
+void ProjRewindForPhys(entity e, float target_time) {
+    RL_RewindTo(rewind_players, e.owner, target_time);
+}
+
+void NoRewindSyncFn(entity e, float target_time) {
+    error("not set\n");
 }
 
 void Forward_Projectile(int fpp_type, entity proj) {
@@ -312,7 +334,7 @@ void Forward_Projectile(int fpp_type, entity proj) {
     float stime = time - dynamic_dt;
 
     float no_rewind = proj.fpp.flags & FPF_NO_REWIND;
-    float rewind_hit = !no_rewind && RewindFlagEnabled(REWIND_PROJ_HIT);
+    float rewind_hit = !no_rewind && RewindFlagEnabled(REWIND_PROJ_FIRE);
     float phys_flags = PHYSF_CONSUME_ALL;
     if (rewind_hit) {
         phys_flags |= PHYSF_REWIND_PLAYERS;
@@ -337,6 +359,7 @@ void Forward_Projectile(int fpp_type, entity proj) {
     if (!proj.voided) {
         RewindSyncTime = ProjRewindForPhys;
         ft += Phys_Advance(proj, time, phys_flags);
+        RewindSyncTime = NoRewindSyncFn;
     }
 
     if (rewind_hit)


### PR DESCRIPTION
The QW protocol is fairly asynchronous in its event ordering; with much being driven off new player packets rather than constant time boundaries.  Try using rewind positions in projectile travel to improve/make registration more consistent.