### PR TITLE
spec: handle throw without prime

### DIFF
--- a/csqc/events.qc
+++ b/csqc/events.qc
@@ -118,7 +118,10 @@ void() CSQC_Parse_Event = {
                 return;
 
             CsGrenTimer last = CsGrenTimer::GetLast();
-            last.set_thrown();
+            // It's possible to get THROWN without PRIMED when spectating a
+            // player that primed before you started watching them.
+            if (last != world && last.active())
+                last.set_thrown();
             break;
         case MSG_TFX_GRENTIMER:
             float entnum = readentitynum();


### PR DESCRIPTION
When spectating an already primed player, off a fresh connect, it's possible to get a throw message with no prime, meaning there's no last grenade timer to set thrown on.