### PR TITLE
wp: fix is_alive to be health>0

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -691,7 +691,7 @@ void _Sync_ServerCommandFrame() {
     }
 
     // Note: When spectating someone, refers to them.
-    game_state.is_alive = getstatf(STAT_HEALTH) >= 0;
+    game_state.is_alive = getstatf(STAT_HEALTH) > 0;
     game_state.spawn_gen = getstatf(STAT_SPAWN_GEN);
 
     WP_ServerFrame();


### PR DESCRIPTION
Refactoring accidentally had this as >= 0