### PR TITLE
wp: free duplicate entities, force refresh on swap

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -96,7 +96,7 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     FO_Hud_Init();
     FO_Weapons_Init();
     Predict_InitDefaultConfig();
-    FO_PP_Init();       // Some of this is always used by custom projectiles.
+    FO_Predict_Init();
     CsGrenTimer::Init();
 
     slot_history_top = -1;

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1303,7 +1303,14 @@ inline float get_phys_time(entity e) {
     }
 }
 
-void FO_PP_Init() {
+void FO_Predict_Init() {
+    entity viewmodel = spawn();
+    viewmodel.drawmask = MASK_PRED_ENT;
+    viewmodel.renderflags = RF_VIEWMODEL | RF_DEPTHHACK;
+    pengine.viewmodel = viewmodel;
+
+    WP_InitSniper();
+
     // Entity we'll attach locally generated sound to.
     pred_sound_entity = spawn();
 
@@ -1993,16 +2000,13 @@ float WP_ClientThink() {
 }
 
 void InitWeapPredEnt(entity pe) {
-    WP_InitSniper();
+    if (pengine.pweap_ent != world) {
+        remove(pengine.pweap_ent);
+    }
 
     pe.predraw = WP_ClientThink;
-    pengine.pweap_ent = pe;
     pe.drawmask = MASK_PRED_ENT;
-
-    entity viewmodel = spawn();
-    viewmodel.drawmask = MASK_PRED_ENT;
-    viewmodel.renderflags = RF_VIEWMODEL | RF_DEPTHHACK;
-    pengine.viewmodel = viewmodel;
+    pengine.pweap_ent = pe;
 
     wp_ready = TRUE;
 }

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -25,6 +25,7 @@ enumflags {
     FOWP_PREDICT_FLAGS,
     FOWP_LAST,
 };
+const float FOWP_ALL = FOWP_LAST - 1;
 
 enumflags {
     FOPP_NEW,
@@ -318,8 +319,14 @@ predict_tf_state pstate_pred, pstate_server;
 
 .float pred_lastforce;
 .float pred_forcebit;
+.entity last_pred_src;
 
 static float Prediction_ChangedMask(entity player, entity src) {
+    if (src != player.last_pred_src) {
+        player.last_pred_src = src;
+        return FOWP_ALL;
+    }
+
     float mask = FOWP_CTIME;
 
     player.predict_state.client_time = src.client_time;
@@ -747,9 +754,6 @@ void Predict_Init() {
 void Predict_InitPlayer(entity player) {
     if (player.predict_entity)
         return;
-
-    sprint(player, PRINT_HIGH,
-            "FortressOne: Weapon Prediction ", wp_version, "\n");
 
     entity pe = spawn();
     pe.owner = player;

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -3043,6 +3043,7 @@ void () ClientConnect = {
     }
 
     bprint(PRINT_HIGH, self.netname, " entered the game\n");
+    sprint(self, PRINT_HIGH, "FortressOne: Weapon Prediction ", wp_version, "\n");
 
     spawnfunc_FOPlayer();
 


### PR DESCRIPTION
Clients transition between entities on entering/leaving the game, which allows for weapon prediction to be initialized more than once now that we also use it for spectators.  Free old initializations when this occurs.

Also force aggressve refresh when spectating a new player.