### PR TITLE
antilag: rewind for death projectiles

### DIFF
--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -1662,12 +1662,15 @@ void WP_Attack() {
     pstate_pred.client_thinkindex = 1;
 
     if (IsEffectFrame() && !in_anim) {
+        float send_event = FALSE;
         switch (wi->weapon) {
             case WEAP_ROCKET_LAUNCHER:
                 PP_CreateProjectile(FPP_ROCKET, v_forward * 8);
+                send_event = TRUE;
                 break;
             case WEAP_INCENDIARY:
                 PP_CreateProjectile(FPP_INCENDIARY, v_forward * 8);
+                send_event = TRUE;
                 break;
             case WEAP_FLAMETHROWER:
                 PP_CreateProjectile(FPP_FLAMETHROWER, v_forward * 16);
@@ -1683,6 +1686,7 @@ void WP_Attack() {
                 break;
 
             case WEAP_GRENADE_LAUNCHER:
+                send_event = TRUE;
             case WEAP_PIPE_LAUNCHER:
                 if (QcPhysics())
                     W_FireGrenade((wi->weapon == WEAP_GRENADE_LAUNCHER || prematch) ?
@@ -1702,6 +1706,15 @@ void WP_Attack() {
             case WEAP_SHOTGUN: Pred_Sound(SND_SG); break;
             case WEAP_SUPER_SHOTGUN: Pred_Sound(SND_SSG); break;
             case WEAP_SNIPER_RIFLE: Pred_Sound(SND_SNIPER_RIFLE); break;
+        }
+
+        if (send_event && RewindFlagEnabled(REWIND_SENDEVENT)) {
+            // It's slightly confusing that we pass server and not pred here,
+            // but this includes the ping adjustment that would occur at pred.
+            // Tested both ways and this seems to be more stable.
+            sendevent("Attack", "ifvv",
+                      (float)wi->weapon, pstate_server.client_time,
+                      pmove_org, input_angles);
         }
     }
 

--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -54,6 +54,7 @@ enumflags {
     REWIND_KNOCKBACK,
     REWIND_SETSPEED,
     REWIND_GRENADES,
+    REWIND_SENDEVENT,
     REWIND_FORWARD_PROJ_SELFKNOCK,
     REWIND_FORWARD_DOORS,
 };
@@ -64,6 +65,7 @@ string REWIND_DESC[] = {
     "rewind pipe knockback",
     "allow csqc to handle maxspeed",
     "rewind grenade throws",
+    "use sendevent augmentation (allows race w/ death rewind)",
     "forward projectile self-knockback",
     "open doors earlier for hpbs [requires rfd=1]",
 };
@@ -71,7 +73,7 @@ string REWIND_DESC[] = {
 const float REWIND_DEFAULT_FLAGS = REWIND_KNOCKBACK | REWIND_PROJ_FIRE |
                                    REWIND_PROJ_TRAVEL |
                                    REWIND_FORWARD_PROJ_SELFKNOCK |
-                                   REWIND_SETSPEED;
+                                   REWIND_SETSPEED | REWIND_SENDEVENT;
 
 
 float RewindFlagEnabled(float flag) {

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -860,7 +860,7 @@ void PredProj_Sound(int proj_type, float vol = 1) {
     Pred_Sound(FPP_Get(proj_type)->snd, vol);
 }
 
-void Forward_Projectile(int fpp_type, entity projectile);
+void Forward_Projectile(int fpp_type, entity projectile, float use_ctime=0);
 
 entity FOProj_Create(int fpp_type) {
     entity prj = spawn();
@@ -873,7 +873,7 @@ entity FOProj_Create(int fpp_type) {
     return prj;
 }
 
-void FOProj_Finalize(entity mis) {
+void FOProj_Finalize(entity mis, float use_ctime=0) {
     int fpp_type = mis.fpp.index;
     // We explicitly do not use newmis.  Newmis internally implements a fixed
     // 50m forward of physics handling (equivalent to our projection below)
@@ -906,7 +906,7 @@ void FOProj_Finalize(entity mis) {
     if (fo_config.qc_physics)
         mis.customphysics = FO_CustomPhysics;
 
-    Forward_Projectile(mis.fpp.index, mis);
+    Forward_Projectile(mis.fpp.index, mis, use_ctime);
 
     // Below is conditional on using custom SendEntity.
     if (csqc_networking) {

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -68,17 +68,10 @@ float () RejoinWithTfId;
 void () CreateTfIdAndJoin;
 entity (entity e)TeamFortress_GetPracticeSpawn;
 void () NextLevel;
-void CSEv_SetPlayerImpulse_f(float n);
 
 void StopAssCan();
 void Predict_InitPlayer(entity player);
 void Predict_Destroy(entity player);
-
-void (float n) CSEv_SetPlayerImpulse_f = {
-    bprint(PRINT_HIGH, self.netname, "\n");
-    bprint(PRINT_HIGH, "setting impulse ", ftos(n), "\n");
-    self.impulse = n;
-};
 
 void () info_intermission =
 {

--- a/ssqc/player.qc
+++ b/ssqc/player.qc
@@ -439,6 +439,7 @@ void () GibPlayer = {
 
 void () PlayerDie = {
     self.spawn_gen += 1;
+    self.last_death_ctime = self.client_time;
 
     local float i;
     local entity te;

--- a/ssqc/pyro.qc
+++ b/ssqc/pyro.qc
@@ -593,18 +593,17 @@ void () T_IncendiaryTouch = {
     dremove_sent(self);
 };
 
-void () W_FireIncendiaryCannon = {
+void W_FireIncendiaryCannon(vector org, vector v_ang, float use_ctime=0) {
     if (self.ammo_rockets < 3) {
         return;
     }
-    self.ammo_rockets = self.ammo_rockets - 3;
     KickPlayer(-3, self);
     entity proj = FOProj_Create(FPP_INCENDIARY);
     proj.owner = self;
     proj.movetype = MOVETYPE_FLYMISSILE;
     proj.solid = SOLID_BBOX;
 
-    makevectors(self.v_angle);
+    makevectors(v_ang);
     proj.velocity = aim(self, 1000) * FPP_Get(FPP_INCENDIARY)->speed;
     proj.angles = vectoangles(proj.velocity);
     proj.touch = T_IncendiaryTouch;
@@ -612,9 +611,9 @@ void () W_FireIncendiaryCannon = {
     proj.nextthink = time + 5;
     proj.weapon = DMSG_INCENDIARY;
     proj.classname = "pyro_rocket";
-    setorigin(proj, self.origin + v_forward * 8 + '0 0 16');
+    setorigin(proj, org + v_forward * 8 + '0 0 16');
 
-    FOProj_Finalize(proj);
+    FOProj_Finalize(proj, use_ctime);
 };
 
 void () AirBlastReloadFinished = {

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -14,6 +14,8 @@ struct antilag_settings_t {
 } antilag_settings;
 
 .vector antilag_origin;
+.float last_death_ctime;
+.float last_attack_ctime;
 
 .float client_time;              // A stable/predictable client clock
 .float client_ping;              // ping used for prediction

--- a/ssqc/rewind.qc
+++ b/ssqc/rewind.qc
@@ -323,8 +323,14 @@ void NoRewindSyncFn(entity e, float target_time) {
     error("not set\n");
 }
 
-void Forward_Projectile(int fpp_type, entity proj) {
+void Forward_Projectile(int fpp_type, entity proj, float use_ctime) {
     float ping = proj.owner.client_ping;
+    if (use_ctime) {
+        // These can be pretty late with sendevent latency on top so let's be
+        // conservative.
+        ping = min((proj.owner.client_time - use_ctime) * 1000,
+                   fo_config.max_rewind_ms - 25);
+    }
 
     ProjectResult offset = Forward_ProjectOffset(fpp_type, ping);
     float static_dt = offset.static_ms / 1000.0;

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -96,7 +96,7 @@ void () BioInfection_MonsterDecay;
 float (float weap) W_GetSlot;
 float (float weap) W_OldGetSlot;
 void () W_FireFlame;
-void () W_FireIncendiaryCannon;
+void W_FireIncendiaryCannon(vector org, vector angles, float use_ctime=0);
 void () W_FireTranq;
 void () W_FireRailgun;
 
@@ -186,6 +186,7 @@ void (float att_delay) Attack_Finished = {
         att_delay *= 2;
 
     self.attack_finished = self.client_time + att_delay;
+    self.last_attack_ctime = self.client_time;
 };
 
 float* W_ammo_to_p(entity player, AmmoType ammo_type) {
@@ -1103,13 +1104,13 @@ void () T_MissileTouch = {
     dremove_sent(self);
 };
 
-void () W_FireRocket = {
+void W_FireRocket(vector org, vector v_ang, float use_ctime=0) = {
     entity proj = FOProj_Create(FPP_ROCKET);
     proj.owner = self;
     proj.movetype = MOVETYPE_FLYMISSILE;
     proj.solid = SOLID_BBOX;
 
-    makevectors(self.v_angle);
+    makevectors(v_ang);
     proj.velocity = v_forward * FPP_Get(FPP_ROCKET)->speed;
     proj.angles = vectoangles(proj.velocity);
 
@@ -1121,11 +1122,10 @@ void () W_FireRocket = {
 
     proj.weapon = DMSG_ROCKETL;
     proj.classname = "proj_rocket";
-    proj.origin = self.origin + v_forward * 8 + '0 0 16';
+    proj.origin = org + v_forward * 8 + '0 0 16';
 
-    FOProj_Finalize(proj);
+    FOProj_Finalize(proj, use_ctime);
 
-    self.ammo_rockets = self.ammo_rockets - 1;
     KickPlayer(-2, self);
 };
 
@@ -1320,8 +1320,7 @@ void () ExplodeOldestPipebomb = {
     }
 };
 
-void () W_FireGrenade = {
-    self.ammo_rockets = self.ammo_rockets - 1;
+void W_FireGrenade(vector org, vector v_ang, float use_ctime=0) {
     Pred_Sound(SND_GREN);
     KickPlayer(-2, self);
 
@@ -1349,7 +1348,7 @@ void () W_FireGrenade = {
         proj.team_no = self.team_no;
         proj.fpp.gren_type = GREN_PIPE;
     }
-    makevectors(self.v_angle);
+    makevectors(v_ang);
     if (self.v_angle_x) {
         proj.velocity = (v_forward * 600) +
             (200 + shared_crandom(PRNG_WEAP) * 10) * v_up +
@@ -1361,9 +1360,9 @@ void () W_FireGrenade = {
     }
     proj.angles = vectoangles(proj.velocity);
     proj.think = GrenadeExplode;
-    setorigin(proj, self.origin);
+    setorigin(proj, org);
 
-    FOProj_Finalize(proj);
+    FOProj_Finalize(proj, use_ctime);
 };
 
 void () spike_touch;
@@ -1694,15 +1693,18 @@ void () W_Attack = {
         player_nail1();
     } else if (ws.weapon == WEAP_GRENADE_LAUNCHER) {
         player_rocket1();
-        W_FireGrenade();
+        self.ammo_rockets = self.ammo_rockets - 1;
+        W_FireGrenade(self.origin, self.v_angle);
         Status_Refresh(self);
     } else if (ws.weapon == WEAP_PIPE_LAUNCHER) {
         player_rocket1();
-        W_FireGrenade();
+        self.ammo_rockets = self.ammo_rockets - 1;
+        W_FireGrenade(self.origin, self.v_angle);
         Status_Refresh(self);
     } else if (ws.weapon == WEAP_ROCKET_LAUNCHER) {
         player_rocket1();
-        W_FireRocket();
+        self.ammo_rockets = self.ammo_rockets - 1;
+        W_FireRocket(self.origin, self.v_angle);
         Status_Refresh(self);
     } else if (ws.weapon == WEAP_LIGHTNING) {
         player_light1();
@@ -1729,7 +1731,8 @@ void () W_Attack = {
     } else if (ws.weapon == WEAP_INCENDIARY) {
         if (self.ammo_rockets >= 3) {
             player_rocket1();
-            W_FireIncendiaryCannon();
+            self.ammo_rockets = self.ammo_rockets - 3;
+            W_FireIncendiaryCannon(self.origin, self.v_angle);
         } else if (time >= self.antispam_incendiary_cannon) {
             sprint(self, PRINT_HIGH, "Not enough ammo\n");
             self.antispam_incendiary_cannon = time + 3;
@@ -2714,5 +2717,31 @@ void () ToggleInvincibility = {
         self.invincible_time = 1;
         self.tfstate = self.tfstate | TFSTATE_INVINCIBLE;
         self.invincible_finished = time + 666;
+    }
+};
+
+// TODO: trust the client less, validate more.
+// TODO: Could support hitscan (e.g. sg/ssg)
+void (float weap, float ctime, vector pos, vector angles) CSEv_Attack_ifvv = {
+    if (!RewindFlagEnabled(REWIND_SENDEVENT))
+        return;
+
+    // Only applies to attacks before the last death.   We can't use
+    // attack_finished here as there's an 0.3s lockout on spawn that obscures.
+    float lockout = 15*MSEC;  // Be a tiny bit conservative
+    if (ctime >= self.last_death_ctime - lockout ||
+        ctime < self.last_attack_ctime - lockout)
+        return;
+
+    switch (weap) {
+        case WEAP_ROCKET_LAUNCHER:
+            W_FireRocket(pos, angles, ctime);
+            break;
+        case WEAP_INCENDIARY:
+            W_FireIncendiaryCannon(pos, angles, ctime);
+            break;
+        case WEAP_GRENADE_LAUNCHER:
+            W_FireGrenade(pos, angles, ctime);
+            break;
     }
 };


### PR DESCRIPTION
It's possible to die in between the time that you fire and the server receives you firing.  This is particularly frustrating since you can often see the client side projectile disappear as a result of the server processing your death first.

Handle this by introducing limited reconciliation that can emit projectiles in this window.  Needs more integration with rewind and hitscan but good enough for a first try.