### PR TITLE
grens: add disable_resup_gren and enable in 2v2

### DIFF
--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -682,6 +682,9 @@ void () DecodeLevelParms = {
         Role_None.gren2_limits[8] = CF_GetSetting("mg2_8", "max_gren2_spy", ftos(PC_SPY_GRENADE_MAX_2));
         Role_None.gren2_limits[9] = CF_GetSetting("mg2_9", "max_gren2_engineer", ftos(PC_ENGINEER_GRENADE_MAX_2));
 
+        // disable resupply giving grenades (1-bit for gren1, 2-bit for gren2)
+        disable_resup_gren = CF_GetSetting("drg", "disable_resup_gren", "0");
+
         // solid detpack toggle [0]
         solid_detpack = CF_GetSetting("sdp", "solid_detpack", "0");
         // All Walls Block EMP [0]

--- a/ssqc/quadmode.qc
+++ b/ssqc/quadmode.qc
@@ -1,5 +1,7 @@
 void () info_player_teamspawn;
 
+void Activate2v2_Ruleset();
+
 void () PostFOQuadStarted = {
 	if (!fo_login_required)
 		return;
@@ -701,8 +703,11 @@ void () StartQuadRound =
 			p = find(p, classname, "player");
 		}
 
-		if (rounds == 2 && legit_players > 1)
+		if (rounds == 2 && legit_players > 1) {
 			PostFOQuadStarted();
+			if (legit_players == 4)
+				Activate2v2_Ruleset();
+		}
 
 		if (rounds == 1 /* final round */) {
 			te = find(world, classname, "player");
@@ -824,3 +829,7 @@ void () StartQuadRound =
 		te.nextthink = (time + 1);
 	}
 };
+
+void Activate2v2_Ruleset() {
+    disable_resup_gren = 3;  // Disable gren1 and gren2 pickups
+}

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -795,6 +795,7 @@ string goal_class_names[7] = {
 
 .float special_cooldown;
 .float airblast_cooldown;
+float disable_resup_gren;
 
 // backend
 string match_id;

--- a/ssqc/tfortmap.qc
+++ b/ssqc/tfortmap.qc
@@ -871,19 +871,14 @@ void (entity Goal, entity Player, entity AP, float addb) Apply_Results = {
                         Player.tfstate &= ~TFSTATE_RELOADING;
                         *ws->clip_fired = max(*ws->clip_fired - Goal.ammo_rockets, 0);
                     }
+                }
 
-                }
-                Player.no_grenades_1 =
-                    Player.no_grenades_1 + Goal.no_grenades_1;
-                Player.no_grenades_2 =
-                    Player.no_grenades_2 + Goal.no_grenades_2;
-                
-                if (Player.no_grenades_1 > Player.max_grenades_1) {
-                    Player.no_grenades_1 = Player.max_grenades_1;
-                }
-                if (Player.no_grenades_2 > Player.max_grenades_2) {
-                    Player.no_grenades_2 = Player.max_grenades_2;
-                }
+                if (disable_resup_gren & 1 == 0)
+                    Player.no_grenades_1 = min(Player.no_grenades_1 + 1,
+                                               Player.max_grenades_1);
+                if (disable_resup_gren & 2 == 0)
+                    Player.no_grenades_2 = min(Player.no_grenades_2 + 1,
+                                               Player.max_grenades_2);
 
                 if (Player.ammo_detpack > Player.maxammo_detpack) {
                     Player.ammo_detpack = Player.maxammo_detpack;


### PR DESCRIPTION
Add a new localinfo {`drg`, `disable_resup_gren`} that allows disabling pack resupply of grenade1 (controlled by 1-bit) and grenade2 (controlled by 2-bit)

e.g.
  `rcon localinfo drg 1` -- disable picking up gren1s
  `rcon localinfo drg 3` -- disable picking up gren1s and gren2s

Does not affect backpack grenade pickup.

Automatically enabled (=3) for 2v2 quads.