### PR TITLE
pmove: infrastructure and bare implementation

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -907,3 +907,7 @@ float(float playernum, string keyname, optional float assumevalue) getplayerkeyf
 		Cheaper version of getplayerkeyvalue that avoids the need for so many tempstrings. */
 float(string key, optional float assumevalue) serverkeyfloat = #0:serverkeyfloat; /*
 		Version of serverkey that returns the value as a float (which avoids tempstrings). */
+
+
+vector PM_Org();
+vector PM_Vel();

--- a/csqc/hitfeedback.qc
+++ b/csqc/hitfeedback.qc
@@ -17,11 +17,11 @@ void NewHittext(entity hittext) {
 static void RenderHitText(entity p) {
     const float maxd = 1500, mind = 0;
     vector po = p.origin;
-    vector o = pmove_org;
+    vector o = PM_Org();
 
     float rem = p.hittext_expires - time;
     po.z += (CVARF(fo_hittext_duration) - rem) * CVARF(fo_hittext_speed);
-    vector direc = normalize(po - pmove_org);
+    vector direc = normalize(po - PM_Org());
     makevectors(getviewprop(VF_ANGLES));
 
     float d = v_forward * direc;

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -15,7 +15,6 @@ void Perf_Status();
 void FO_Hud_Init();
 float InFluid(vector point);
 float CalculateWaterLevel();
-void PlayCSJumpSounds();
 void RenderHitTexts();
 
 void GetSelf() = {
@@ -110,6 +109,9 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     registercommand("+slot");
     registercommand("-slot");
 
+    registercommand("fo_beta_pmove");
+    registercommand("fopm_cmd");
+
     registercommand("login");
     registercommand("fo_hud_editor");
     registercommand("fo_hud_reload");
@@ -167,6 +169,7 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     current_vote = world;
     vote_list_filter = "";
 
+    PM_Init();
     TF_Init();
 
     ClientSettings_Check();
@@ -189,6 +192,7 @@ void FO_CussView();
 void FO_CussCrosshair(float width, float height);
 void Hud_UpdateView(float width, float height, float menushown, float perf_sample);
 void UpdateTeamColorCrosshair();
+void PMD_DrawGraphs(float width);
 
 DEFCVAR_FLOAT(fov, 90);
 
@@ -197,7 +201,6 @@ noref void(float width, float height, float menushown) CSQC_UpdateView = {
     clearscene();
     setproperty(VF_DRAWWORLD, 1); 		// we want to draw our world!
     setproperty(VF_DRAWCROSSHAIR, 1);		 // we want to draw our crosshair!
-                                                 //
     FO_CussView();
 
     if (zoomed_in)
@@ -212,6 +215,9 @@ noref void(float width, float height, float menushown) CSQC_UpdateView = {
         mask |= WPP_ViewModelMask();
     addentities(mask);
 
+    if (PM_Enabled())
+        PM_UpdateView();
+
     renderscene();
 
     FO_CussCrosshair(width, height);
@@ -219,6 +225,7 @@ noref void(float width, float height, float menushown) CSQC_UpdateView = {
     TFxRenderGrenadeTimers();
     RenderHitTexts();
     Hud_UpdateView(width, height, menushown, fts);
+    PMD_DrawGraphs(width);
 
     perf_finish_sample(&frame_timing, fts);
 
@@ -257,6 +264,15 @@ noref float(string cmd) CSQC_ConsoleCommand = {
         case "-slot":
             Slot_Keyup(stof(argv(1)));
             break;
+
+        case "fopm_cmd":
+            PM_PmCmd(stof(argv(1)));
+            break;
+
+        case "fo_beta_pmove":
+            PM_PmCmd(!!stof(argv(1)));
+            break;
+
         case "login":
             FoLogin(argv(1), TRUE);
             break;
@@ -578,7 +594,7 @@ static void FO_CussCrosshair(float width, float height) {
 
     cuss_state.cussed = TRUE;
     makevectors(input_angles);  // updated by input_frame
-    vector p = project(pmove_org + 8000 * cuss_state.c_forward);
+    vector p = project(PM_Org() + 8000 * cuss_state.c_forward);
 
     localcmd(sprintf("cl_crossx %d; cl_crossy %d;\n",
                 p_x - width / 2, CVARF(fo_crossy) + p_y - height / 2));
@@ -626,7 +642,7 @@ void FO_ApplyCussInput() {
     }
 }
 
-void FO_ApplyMaxSpeed();
+void FO_ApplyMaxSpeed(float force);
 
 noref void CSQC_Input_Frame() {
     Sync_GameState();
@@ -646,7 +662,7 @@ noref void CSQC_Input_Frame() {
     if (prev_zoomed_in != zoomed_in)
         setsensitivityscaler(zoomed_in ? 1/3 : 1);
 
-    FO_ApplyMaxSpeed();
+    FO_ApplyMaxSpeed(FALSE);
     FO_ApplyCussInput();
 }
 
@@ -711,7 +727,7 @@ void _Sync_ServerCommandFrame() {
 // synchronized with server and predicted state.
 void Sync_GameState() {
     _Sync_ServerCommandFrame();
-    PM_PredictJump();
+    PM_PredictJump_Engine();
 }
 
 static string FoLogin_GetToken() {

--- a/csqc/pmove.qc
+++ b/csqc/pmove.qc
@@ -1,8 +1,46 @@
 DEFCVAR_FLOAT(fo_jumpvolume, 1);
 
-inline float CSQC_JumpSounds_Active() {
-    return CVARF(fo_csjumpsounds);
+static float pm_enabled;
+inline float PM_Enabled() { return pm_enabled; }
+
+#define ERRORTIME 0.05
+#define STEPTIME 8
+
+enumflags {
+    PMF_JUMP_HELD,
+};
+
+// `seq` is the start of the first frame after which all input_*s are handled.
+// Running to `seq` will result in being on frame `seq + 1` in the resultant
+// state.  In the case that `seq == commandclientframe` this could only be
+// partially true since the input_*s (in particular, timelength) are not
+// constant for this frame.
+struct PMS_Data {
+    vector org, vel;
+    float seq;
+} pm_s, pm_so, pm_c;
+
+struct {
+    entity ent;
+    float seq;
+
+    vector error;
+    float errortime;
+
+    float step, steptime, step_oldz;
+
+    vector vieworg;
+} pm;
+
+void PM_PmCmd(float arg) {
+    sendevent("PmCmd", "f", arg);
 }
+
+vector PM_Org() { return PM_Enabled() ? pm.ent.origin : pmove_org; }
+vector PM_Vel() { return PM_Enabled() ? pm.ent.velocity : pmove_vel; }
+inline entity PM_Ent() { return pm.ent; }
+
+inline float CSQC_JumpSounds_Active() { return CVARF(fo_csjumpsounds); }
 
 // Sets *type to whatever is at the feet of `point`.
 static float PM_GetWaterLevel(vector point, float* type) {
@@ -21,35 +59,14 @@ static float PM_GetWaterLevel(vector point, float* type) {
     return waterlevel;
 }
 
-// Some versions of FTE do not correctly update pmove_vel (although other state,
-// e.g. pmove_org is).  Until we're directly tied to pmove, we snoop on recent
-// values when we think this is happening.
-float recent_pmove_vel_z;
-
-void PM_PredictJump() {
-    if (!CSQC_JumpSounds_Active() || getstatf(STAT_PAUSED))
-        return;
-
-    static float last_onground, last_waterlevel, last_vel_z;
-
+static void PM_Sounds(float is_jumping, float is_jumpframe,
+                      float is_landing,
+                      float last_vel_z) {
     float fluidtype;
-    float waterlevel = PM_GetWaterLevel(pmove_org, &fluidtype);
-    float jumping = input_buttons & BUTTON2;
-    float onground = pmove_onground;
-    float landing = onground && !last_onground;
-    float vel_z = pmove_vel_z ?: recent_pmove_vel_z;
+    static float last_waterlevel;  // Hacky ...
+    float waterlevel = PM_GetWaterLevel(PM_Org(), &fluidtype);
 
-    if (!game_state.is_alive) {
-        last_onground = 1;
-        last_vel_z = 0;
-        last_waterlevel = 0;
-        return;
-    }
-
-    static float swimsound_next;
-
-    string sound;
-    if (landing && last_vel_z < -300) {  // Hard or water land.
+    if (is_landing && last_vel_z < -300) {  // Hard or water land.
         if (fluidtype == CONTENT_WATER)
             localsound("player/h2ojump.wav", CHAN_BODY, 1);
         else if (last_vel_z < -650)  // Will take damage.
@@ -59,12 +76,15 @@ void PM_PredictJump() {
     }
 
     // TODO: Model health above and not play jump when landing into death.
-    if (jumping) {
-        if (waterlevel >= 2 && time > swimsound_next) {
-            swimsound_next = time + 1;
-            sound = random() < 0.5 ? "player/water1.wav" : "player/water2.wav";
-            localsound(sound, CHAN_BODY, 1);
-        } else if (last_onground && !onground && vel_z > last_vel_z + 200) {
+    if (is_jumping) {
+        static float swimsound_next;
+        if (waterlevel >= 2) {
+           if (time > swimsound_next) {
+               swimsound_next = time + 1;
+               localsound(random() < 0.5 ? "player/water1.wav" : "player/water2.wav",
+                          CHAN_BODY, 1);
+           }
+        } else if (is_jumpframe) {
             // The default pmove implementation and server behave slightly
             // differently here in two important ways here:
             // 1) Jump calculations run _prior_ to movement rather than post,
@@ -80,7 +100,7 @@ void PM_PredictJump() {
     }
 
     if (waterlevel > 0 && last_waterlevel == 0) {  // Water entry.
-        sound = "";
+        string sound = "";
         switch(fluidtype) {
             case CONTENT_LAVA: sound = "player/inlava.wav"; break;
             case CONTENT_WATER: sound = "player/inh2o.wav"; break;
@@ -91,7 +111,377 @@ void PM_PredictJump() {
         localsound("misc/outwater.wav", CHAN_BODY, 1);
     }
 
+    last_waterlevel = waterlevel;
+}
+
+// Some versions of FTE do not correctly update pmove_vel (although other state,
+// e.g. PM_Org() is).  Until we're directly tied to pmove, we snoop on recent
+// values when we think this is happening.
+float recent_pmove_vel_z;
+
+void PM_PredictJump_Engine() {
+    if (!CSQC_JumpSounds_Active() || getstatf(STAT_PAUSED))
+        return;
+
+    if (PM_Enabled())  // Handled by PredictJump_Pmove
+        return;
+
+    static float last_onground, last_vel_z;
+
+    float jumping = input_buttons & BUTTON2;
+    float onground = pmove_onground; //pmove_onground;
+    float landing = (onground && !last_onground);
+    float vel_z = pmove_vel_z ?: recent_pmove_vel_z;
+
+    if (!game_state.is_alive) {
+        last_onground = 1;
+        last_vel_z = 0;
+        return;
+    }
+
+    float is_jump = last_onground && !onground && vel_z > last_vel_z + 200;
+
+    PM_Sounds(jumping, is_jump, landing, last_vel_z);
+
     last_vel_z = vel_z;
     last_onground = onground;
-    last_waterlevel = waterlevel;
 };
+
+////////////////////////////////////////////////////////////////////////////////
+// Pmove
+////////////////////////////////////////////////////////////////////////////////
+
+enum {
+    SERVER,
+    PMOVE,
+    VIEW,
+    NUM_DBG_GRAPH_TYPES,
+};
+
+DEFCVAR_FLOAT(fopmd_graph_x, -10);
+DEFCVAR_FLOAT(fopmd_graph_y, 100);
+DEFCVAR_FLOAT(fopmd_graph_w, 200);
+DEFCVAR_FLOAT(fopmd_graph_h, 100);
+
+DEFCVAR_FLOAT(fopm_noerror, 0);
+DEFCVAR_FLOAT(fopm_nocache, 0);
+DEFCVAR_FLOAT(fopm_nostep, 0);
+
+DEFCVAR_FLOAT(v_viewheight, 0);
+
+enumflags {
+    PMDG_ON,
+    PMDG_NO_ALIGN_INTERP,
+};
+DEFCVAR_FLOAT(fopmd_graph, 0);
+
+void PM_Init() {
+    pm.ent = spawn();
+    pm.ent.solid = SOLID_NOT;
+    pm.ent.movetype = MOVETYPE_WALK;
+    setsize(pm.ent, '-16 -16 -24', '16 16 32');
+}
+
+// Should be invoked immediately after RunMovement() to ensure correctness of
+// `seq` versus state.  On server packets we manually set `seq` to sf + 1.
+static inline void PM_SavePMS(PMS_Data *pms) {
+    entity ent = pm.ent;
+    pms->org = ent.origin;
+    pms->vel = ent.velocity;
+    pms->seq = pm.seq;
+}
+
+static inline void PM_ActivatePMS(PMS_Data *pms) {
+    entity ent = pm.ent;
+    ent.origin = pms->org;
+    ent.velocity = pms->vel;
+    pm.seq = pms->seq;
+};
+
+static void PM_RunMovement(float endframe) {
+    entity ent = pm.ent;
+    if (servercommandframe >= pm_s.seq + 63) {
+        // We're meant to be updating the player faster than this
+        // hopefully its just that we're throttled...
+        // Uncommenting this block will result in the player continuing to be
+        // predicted rather than frozen.
+        pm_s.seq = servercommandframe - 63;
+        return;
+    }
+
+    if (endframe < pm.seq) {
+        if (endframe >= pm_c.seq && !CVARF(fopm_nocache))
+            PM_ActivatePMS(&pm_c);
+        else
+            PM_ActivatePMS(&pm_s);
+    }
+
+
+    if (!game_state.is_alive) {
+        pm.seq = clientcommandframe;
+        //just update the angles
+        if (!getinputstate(pm.seq-1)) { }
+        return;
+    }
+
+    if (pm.seq < clientcommandframe - 128)
+        pm.seq = clientcommandframe - 128;
+
+    while (pm.seq <= endframe) {
+        if (!getinputstate(pm.seq))
+            break;
+
+        // We have to apply this on the leading edge since INPUT_FRAME
+        // modifications do not occur until the frame is finalized.
+        if (pm.seq == clientcommandframe)
+            FO_ApplyMaxSpeed(TRUE);
+
+        pm.ent.pmove_flags = 0;  // With auto-bunny we only care about clearing
+        runstandardplayerphysics(ent);
+
+        pm.seq++;
+    }
+
+    // Add in anything that was applied after (for low packet rate protocols)
+    input_angles = view_angles;
+};
+
+static void PM_SetEnabled(float enabled) {
+    pm_enabled = enabled;
+    pm.ent.solid = enabled ? SOLID_SLIDEBOX : SOLID_NOT;
+
+    if (!enabled)
+        return;
+
+    pm.errortime = 0;
+    pm.steptime = 0;
+    pm.step_oldz = pm.ent.origin_z;
+}
+
+static void PM_UpdateError() {
+    entity ent = pm.ent;
+
+    if (CVARF(fopm_noerror)) {
+        pm.error = '0 0 0';
+        pm.errortime = 0;
+        return;
+    }
+
+    // Run prior prediction to present.
+    PM_ActivatePMS(&pm_so);
+    PM_RunMovement(clientcommandframe);
+    vector err = ent.origin;
+
+    // Repeat with updated state.
+    PM_ActivatePMS(&pm_s);
+    PM_RunMovement(clientcommandframe);
+
+    err -= ent.origin;
+    float nerr = vlen(err);
+    if (nerr > 128) {  // teleport
+        pm.error = '0 0 0';
+        pm.errortime = 0;
+    } else { // figure out the error amount, and add it to accumulated lerp
+        pm.error *= max(pm.errortime - time, 0) / ERRORTIME;
+        pm.error += err;
+        pm.errortime = vlen(pm.error) > 1 ? time + ERRORTIME : 0;
+    }
+}
+
+static void PM_UpdateLocalMovement() {
+    entity ent = pm.ent;
+
+    /* PM_ActivatePMS(&pm_c); */
+    PM_RunMovement(clientcommandframe);
+    vector org = pm.ent.origin;
+
+
+    // Smooth stair stepping
+    if (org_z > pm.step_oldz + 8 && org_z < pm.step_oldz + 24 &&
+        ent.velocity_z == 0) { // Evaluate out the remaining old step
+        if (pm.steptime - time > 0)
+            pm.step = (pm.steptime - time) * STEPTIME * pm.step;
+        else
+            pm.step = 0;
+
+        // Work out the new step
+        pm.step += (pm.step_oldz - org_z);
+        pm.steptime = time + 1 / STEPTIME;
+    }
+    pm.step_oldz = org_z;
+
+    float viewheight = CVARF(v_viewheight);
+    if (viewheight < -7)
+        viewheight = -7;
+    else if (viewheight > 7)
+        viewheight = 7;
+
+    pm.vieworg = org;
+    pm.vieworg.z += getstatf(STAT_VIEWHEIGHT) + viewheight;
+
+    // Correct view position over ERRORTIME
+    if (pm.errortime - time > 0)
+        pm.vieworg += (pm.errortime - time) * (1 / ERRORTIME) * pm.error;
+
+    if (!CVARF(fopm_nostep))
+        if (pm.steptime - time > 0)
+            pm.vieworg.z += (pm.steptime - time) * STEPTIME * pm.step;
+}
+
+void PMD_UpdateImpulse(int seq);
+
+void PM_SyncTo(float seq) {
+    if (!PM_Enabled())
+        return;
+
+    entity ent = pm.ent;
+
+    PM_RunMovement(seq - 1);
+    float of = ent.flags;
+    float last_vel_z = ent.velocity_z;
+
+    PM_RunMovement(seq);
+    float nf = ent.flags;
+
+    if (!CSQC_JumpSounds_Active())
+        return;
+
+    // Note: ~FL_ONGROUND and jump occur in same frame, produces JUMP_HELD
+    float jumping = input_buttons & BUTTON2;
+    float landing = (!(of & FL_ONGROUND) && (nf & FL_ONGROUND));
+    float jump_frame = ent.pmove_flags & PMF_JUMP_HELD;
+
+    PM_Sounds(jumping, jump_frame, landing, last_vel_z);
+}
+
+void PM_Update(float sendflags) {
+    float was_enabled = PM_Enabled();
+    float enabled = ((pstate_server.predict_flags & PF_PMOVE) &&
+                     (game_state.is_player));
+
+    if (enabled != was_enabled)
+        PM_SetEnabled(enabled);
+
+    if (sendflags & FOWP_PMOVE == 0)
+        return;
+
+    pm_so = pm_s;
+    pm.seq = servercommandframe + 1;  // server state includes move
+    PM_SavePMS(&pm_s);
+
+    // Pre-compute predicted movement for all locked frames (e.g. seq <
+    // clientcommandframe) so that we can accelerate the common case of
+    // computation at clientcommandframe (which does require constant
+    // re-evaluation).  In the case there's no separation (e.g. lan pings) then
+    // the server frame is directly used as the cache frame.
+    if (clientcommandframe > servercommandframe + 1)
+        PM_RunMovement(clientcommandframe - 1);
+    PM_SavePMS(&pm_c);
+
+    if (enabled && was_enabled)
+        PM_UpdateError();
+
+    PMD_UpdateImpulse(servercommandframe);
+}
+
+void PM_UpdateView() {
+    PM_UpdateLocalMovement();
+    setviewprop(VF_ORIGIN, pm.vieworg);
+    setviewprop(VF_ANGLES, view_angles);
+
+    makevectors(view_angles);
+    SetListener(pm.vieworg, v_forward, v_right, v_up);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Debug
+////////////////////////////////////////////////////////////////////////////////
+
+static const float NIMP = 300;
+struct PmoveDebug {
+    float points[NIMP];
+    int nimp;
+};
+
+static PmoveDebug pmd[NUM_DBG_GRAPH_TYPES];
+
+static void PMD_AddPoint(int ptype, float val) {
+    PmoveDebug* pd = &pmd[ptype];
+
+    pd->points[pd->nimp++ % NIMP] = val;
+}
+
+static void PMD_UpdateImpulse(int seq) {
+    if (!CVARF(fopmd_graph))
+        return;
+
+    static int old_seq;
+    if (old_seq == seq)
+        return;
+    old_seq = seq;
+
+    if (PM_Enabled())
+        PM_RunMovement(clientcommandframe);
+
+    vector sv = pm_s.vel;
+    vector pv = PM_Vel();
+
+    if (!vlen(pv) && !vlen(sv))
+        return;
+
+    PMD_AddPoint(SERVER, vlen(sv));
+    PMD_AddPoint(PMOVE,  vlen(pv));
+    PMD_AddPoint(VIEW, vlen(pm.error) / 128 * 1200);
+}
+
+static void PMD_Graph(int type, int offset, vector c1, vector c2, vector rgb) {
+    PmoveDebug* pd = &pmd[type];
+    float wx = c2.x - c1.x, wy = c2.y - c1.y;
+
+    float maxv = pd->points[0], minv = pd->points[0];
+    for (int i = 1; i < NIMP; i++) {
+        maxv = max(maxv, pd->points[i]);
+        minv = min(minv, pd->points[i]);
+    }
+
+    float h = max(maxv - minv, 1200);
+
+    float px = wx / NIMP, py = (wy - 2) / h;
+    vector lend = c1 + [0, wy, 0];
+
+    vector m1 = [0, wy - maxv * py, 0];
+    drawline(1, c1 + m1, c1 + m1 + [wx, 0, 0], '50 150 150', 1);
+
+    for (int i = offset; i < NIMP; i++) {
+        int idx = (pd->nimp + i) % NIMP;
+        vector sx =
+            [c1.x + (i - offset) * px, c2.y - (pd->points[idx]) * py + 1, 0];
+        vector sy = [sx.x + px, sx.y, 0];
+
+        drawline(1, sx, sy, rgb, 1);
+        drawline(1, lend, sx, rgb, 1);
+        lend = sy;
+    }
+}
+
+void PMD_DrawGraphs(float width) {
+    if (!CVARF(fopmd_graph))
+        return;
+
+    vector c1 = [CVARF(fopmd_graph_x), CVARF(fopmd_graph_y), 0];
+    if (c1.x < 0)
+        c1.x += width - CVARF(fopmd_graph_w);
+    vector w =  [CVARF(fopmd_graph_w), CVARF(fopmd_graph_h), 0];
+    vector c2 = c1 + w;
+
+    drawfill(c1, w, '0.2 0.2 0.2', 1);
+    drawfill(c2, '5 5 5', '1 0 0', 1);
+
+    float offset = (CVARF(fopmd_graph) & PMDG_NO_ALIGN_INTERP) ? 0 :
+        clientcommandframe - servercommandframe;
+
+    offset = max(0, offset);
+    PMD_Graph(PMOVE, 0, c1, c2, '0 0 1');
+    PMD_Graph(VIEW, 0, c1, c2, '0 1 0');
+    PMD_Graph(SERVER, offset, c1, c2, '1 0 0');
+}

--- a/csqc/status.qc
+++ b/csqc/status.qc
@@ -993,7 +993,9 @@ static SpeedBarColors speedbar_colors[] = {
 };
 
 static float PlanarSpeed() {
-    return vlen([pmove_vel.x, pmove_vel.y, 0]);
+    vector pvel = PM_Vel();
+    pvel.z = 0;  // compiler bug: pvel becomes [1 0 0] if this is inlined
+    return vlen(pvel);
 }
 
 void drawSpeedBar(PanelID panelid, string text) {

--- a/csqc/tfx.qc
+++ b/csqc/tfx.qc
@@ -154,7 +154,7 @@ static float next_grenlist_update;
 static float RenderGrenTimer(entity p, float test_only) {
     const float maxd = 1000, mind = 200;
     vector po = p.origin + '0 0 40';
-    vector o = pmove_org;
+    vector o = PM_Org();
 
     if (p == local_player)
         return FALSE;

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -585,7 +585,9 @@ void PredProj_Sound(int proj_type, float vol = 1) {
     Pred_Sound(FPP_Get(proj_type)->snd, vol);
 }
 
-void WP_ServerUpdate() {
+void PM_Update(float sendflags);
+
+void WP_ServerUpdate(float sendflags) {
     // Force WF to zero, in case we missed a packet.
     if (pstate_server.attack_finished < pstate_server.client_time)
         pstate_server.weaponframe = 0;
@@ -605,6 +607,8 @@ void WP_ServerUpdate() {
         phys_sim_dt = (pstate_server.client_ping + 2 * SERVER_FRAME_MS) / 1000.0;
     else
         phys_sim_dt = -1;
+
+    PM_Update(sendflags);
 }
 
 void FO_ReloadSound(float weapon) {
@@ -789,7 +793,7 @@ static void WP_Sniper_UpdateSight() {
     }
 
     SniperState.sight.drawmask = MASK_ENGINE;
-    vector org = pmove_org + v_forward * 10;
+    vector org = PM_Org() + v_forward * 10;
     org.z += PLAYER_MINS.z - 1 + (PLAYER_MAXS.z - PLAYER_MINS.z) * 0.7;
     traceline(org, org + v_forward * 9192, MOVE_NORMAL, 0);
     setorigin(SniperState.sight, trace_endpos);
@@ -1179,12 +1183,16 @@ void WPP_Dump() {
 
 void WP_Attack();
 
-void FO_ApplyMaxSpeed() {
-    if (!WP_Enabled() || !CVARF(wpp_setspeed) || !RewindFlagEnabled(REWIND_SETSPEED))
+void FO_ApplyMaxSpeed(float force) {
+    if (!force &&
+        (!WP_Enabled() || !CVARF(wpp_setspeed) || !RewindFlagEnabled(REWIND_SETSPEED)))
         return;
 
+    float max_speed = pstate_pred.csqc_maxspeed;
     if (pstate_pred.tfstate & TFSTATE_AIMING)
-        input_movevalues = normalize(input_movevalues) * 80;
+        max_speed = 80;
+    if (vlen(input_movevalues) > max_speed)
+        input_movevalues = normalize(input_movevalues) * max_speed;
 }
 
 DEFCVAR_FLOAT(cl_crossx, 0);
@@ -1430,7 +1438,7 @@ entity PP_CreateProjectile(int fpp_type, vector offset) {
   proj.drawmask = MASK_PRED_PROJECTILE;
 
   setsize(proj, [0,0,0], [0,0,0]);
-  proj.origin = pmove_org + offset;
+  proj.origin = PM_Org() + offset;
 
   float proj_speed = FPP_Get(fpp_type)->speed;
   if (!FPP_IsGrenade(fpp_type)) {
@@ -1596,7 +1604,7 @@ static void W_ThrowGren(float is_throw) {
 
 
 void FO_FireAssCanPellet(vector org, vector dir, float proj_speed, int index) {
-    vector offset = org - pmove_org - '0 0 16';
+    vector offset = org - PM_Org() - '0 0 16';
     entity proj = PP_CreateProjectile(FPP_ASSAULT_CANNON, offset);
 
     if (proj == __NULL__)
@@ -1690,7 +1698,7 @@ void WP_Attack() {
             // Tested both ways and this seems to be more stable.
             sendevent("Attack", "ifvv",
                       (float)wi->weapon, pstate_server.client_time,
-                      pmove_org, input_angles);
+                      PM_Org(), input_angles);
         }
     }
 
@@ -1729,7 +1737,7 @@ void WP_Attack() {
 
 void PredProjectile_DebugMatch(entity cprj, entity sprj) {
     string sgn =
-        vlen(cprj.origin - pmove_org) > vlen(sprj.origin- pmove_org) ? "+" : "-";
+        vlen(cprj.origin - PM_Org()) > vlen(sprj.origin- PM_Org()) ? "+" : "-";
 
     string s = sprintf(" p_diff: %s%-2.1f [%0.3f] ", sgn,
                     vlen(cprj.origin - sprj.origin),
@@ -1739,7 +1747,7 @@ void PredProjectile_DebugMatch(entity cprj, entity sprj) {
                 sprj.phys_time - cprj.phys_time));
 
     s = strcat(s, sprintf(" [c=%d s=%d] al=%d\n",
-            vlen(cprj.origin - pmove_org), vlen(sprj.origin - pmove_org),
+            vlen(cprj.origin - PM_Org()), vlen(sprj.origin - PM_Org()),
             self.antilag_ms));
     print(s);
 }
@@ -1974,6 +1982,9 @@ static void PredictConc() {
         pstate_pred.tfstate &= ~TFSTATE_CONC;
 }
 
+void PM_SyncTo(float seq);
+void PM_TestJump();
+
 static void WP_UpdatePredict() {
     PredictConc(); // Looks like this is missing time/prediction interp
     getinputstate(servercommandframe); // Setup first read for old_buttons.
@@ -1999,6 +2010,7 @@ static void WP_UpdatePredict() {
         if (pframe == effect_frame && pframe > pengine.last_effectframe) {
             pengine.is_effectframe = TRUE;
             pengine.last_effectframe = pframe;
+            PM_SyncTo(pframe);
         } else {
             pengine.is_effectframe = FALSE;
         }
@@ -2030,9 +2042,12 @@ float WP_ClientThink() {
     return PREDRAW_NEXT;
 }
 
+entity WP_pmove_ent();
+
 void InitWeapPredEnt(entity pe) {
     if (pengine.pweap_ent != world) {
         remove(pengine.pweap_ent);
+        pengine.pweap_ent = world;
     }
 
     pe.predraw = WP_ClientThink;

--- a/share/animate.qc
+++ b/share/animate.qc
@@ -153,7 +153,7 @@ static inline float *tf_state() { return &pstate_pred.tfstate; }
 static inline float is_attacking() { return input_buttons & BUTTON0; }
 static inline float is_intermission() { return intermission; }
 static void SuperDamageSound() {} // TODO
-static inline vector get_velocity() { return pmove_vel; }
+static inline vector get_velocity() { return PM_Vel(); }
 static inline void set_weapon_frame(float f) { pstate_pred.weaponframe = f; }
 static inline void muzzleflash() {}
 float WP_CurrentClipFired();

--- a/share/classes.qc
+++ b/share/classes.qc
@@ -27,7 +27,7 @@ float shared_crandom(int type) {
 #ifdef CSQC
 float WP_GetAmmo(float ammo_type);
 float get_shells() { return WP_GetAmmo(AMMO_SHELLS); }
-static inline vector get_origin() { return pmove_org; }
+static inline vector get_origin() { return PM_Org(); }
 #else
 float get_shells() { return self.ammo_shells; }
 static inline vector get_origin() { return self.origin; }

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -10,6 +10,7 @@ string wp_version = "v1.1";
 
 enumflags {
     FOWP_CTIME,
+    FOWP_PMOVE,
     FOWP_IMPULSE,
     FOWP_TFSTATE,
     FOWP_LASTPRIME,
@@ -43,6 +44,12 @@ enumflags {
     CSQC_PROJ_PRED,
     CSQC_SETSPEED,
     CSQC_SNIPER_SIGHT,
+};
+
+enumflags {
+    PF_PMOVE,
+    PF_POS,
+    PF_PMOVE_ACTIVATING,
 };
 
 struct predict_tf_state {
@@ -320,6 +327,7 @@ predict_tf_state pstate_pred, pstate_server;
 .float pred_lastforce;
 .float pred_forcebit;
 .entity last_pred_src;
+.float predict_flags;
 
 static float Prediction_ChangedMask(entity player, entity src) {
     if (src != player.last_pred_src) {
@@ -331,6 +339,9 @@ static float Prediction_ChangedMask(entity player, entity src) {
 
     player.predict_state.client_time = src.client_time;
     player.predict_state.client_ping = src.client_ping;
+
+    if (player.predict_flags & PF_POS)
+        mask |= FOWP_PMOVE;
 
     M1(FOWP_CLASS, playerclass);
     M4(FOWP_IMPULSE, impulse, current_slot.id, queue_slot.id, last_slot.id);
@@ -344,6 +355,7 @@ static float Prediction_ChangedMask(entity player, entity src) {
     M2(FOWP_RELOAD, reload_started, reload_finished);
     M1(FOWP_RNG0, prng_base[PRNG_WEAP]);
     M1(FOWP_RNG1, prng_base[PRNG_HWGUY]);
+    M1(FOWP_PREDICT_FLAGS, predict_flags);
     M4(FOWP_GREN, no_grenades_1, no_grenades_2, primed_gren_type, primed_gren_exp)
 
     // Rotate through forced update fields.
@@ -354,7 +366,8 @@ static float Prediction_ChangedMask(entity player, entity src) {
         if (player.pred_forcebit >= FOWP_LAST)
             player.pred_forcebit = 1;
 
-        mask |= player.pred_forcebit;
+        if (player.pred_forcebit != FOWP_PMOVE)
+            mask |= player.pred_forcebit;
     }
 
     return mask;
@@ -398,7 +411,7 @@ float() ReadEntity = #368;
 int() ReadInt = #0:readint;
 
 void InitWeapPredEnt(entity e);
-void WP_ServerUpdate();
+void WP_ServerUpdate(float sendflags);
 void InitProjectileEnt(float sendflags);
 void WPP_UpdateEnable(float force);
 
@@ -442,6 +455,7 @@ void EntUpdate_Config() {
 
 #ifdef SSQC
 #define COMM(_type, _field) Write##_type(MSG_ENTITY, self.owner.predict_state.##_field)
+#define COMM_PM(_type, _field) Write##_type(MSG_ENTITY, self.owner.##_field)
 float WP_SendEntity(entity to_player, float sendflags) {
     if (to_player != self.owner)
         return FALSE;
@@ -449,7 +463,10 @@ float WP_SendEntity(entity to_player, float sendflags) {
     WriteByte(MSG_ENTITY, ENT_WEAPONPRED);
     WriteFloat(MSG_ENTITY, sendflags);
 #else
+entity PM_Ent();
 #define COMM(_type, _field) pstate_server.##_field = Read##_type()
+#define COMM_PM(_type, _field) PM_Ent().##_field = Read##_type()
+
 void EntUpdate_WeaponPred(float isnew) {
     float sendflags = readfloat();
 #endif
@@ -459,6 +476,15 @@ void EntUpdate_WeaponPred(float isnew) {
     if (sendflags & FOWP_CTIME) {
         COMM(Float, client_time);
         COMM(Short, client_ping);
+    }
+
+    if (sendflags & FOWP_PMOVE) {
+        COMM_PM(Coord, origin[0]);
+        COMM_PM(Coord, origin[1]);
+        COMM_PM(Coord, origin[2]);
+        COMM_PM(Short, velocity[0]);
+        COMM_PM(Short, velocity[1]);
+        COMM_PM(Short, velocity[2]);
     }
 
     if (sendflags & FOWP_CLASS) {
@@ -529,7 +555,7 @@ void EntUpdate_WeaponPred(float isnew) {
     if (isnew)
         InitWeapPredEnt(self);
     else
-        WP_ServerUpdate();
+        WP_ServerUpdate(sendflags);
 #endif
 }
 #undef COMM

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -3890,3 +3890,49 @@ void() SV_RunClientCommand = {
     self.jump_flag = self.velocity_z;
 }
 */
+
+static void DeferredPmoveAction() {
+    entity player = self.owner;
+    player.predict_flags &= ~PF_PMOVE_ACTIVATING;
+
+    if (self.heat) {
+        sprint(player, PRINT_HIGH, "*** PMOVE ACTIVATED\n");
+        player.nodrawtoclient = player;
+        player.predict_flags |= PF_PMOVE;
+    } else {
+        sprint(self, PRINT_HIGH, "*** PMOVE INACTIVE\n");
+        player.predict_flags &= ~PF_PMOVE;
+    }
+    remove(self);
+}
+
+void (float active) CSEv_PmCmd_f = {
+    sprint(self, PRINT_HIGH, sprintf("*** PMCMD %d\n", active));
+    if (self.predict_flags & PF_PMOVE_ACTIVATING) {
+        sprint(self, PRINT_HIGH, "Please wait for prior activation to complete...\n");
+        return;
+    }
+
+    if (active & PF_PMOVE)
+        active |= PF_POS;
+
+    self.predict_flags &= ~PF_POS;
+    self.predict_flags |= (active & PF_POS);
+
+    if ((active & PF_PMOVE) == (self.predict_flags & PF_PMOVE))
+        return;
+
+    float enable = active & PF_PMOVE;
+    if (enable) {
+        self.maxspeed = PC_SCOUT_MAXSPEED;  // Handled clientside.
+    } else {
+        self.nodrawtoclient = world;
+    }
+
+    self.predict_flags |= PF_PMOVE_ACTIVATING;
+    entity defer = spawn();
+    defer.owner = self;
+    defer.think = DeferredPmoveAction;
+    defer.heat = enable;
+    defer.nextthink = time + 0.1;
+}


### PR DESCRIPTION
Introduces a full integration for CSQC side movement prediction.  I'd originally intended to break this up into more granular commits but some of the refactoring became too painful.

A lot of the base structure is based on the excellent CSQC reference, but with many bugs and a first pass at refinements.  Does some useful things such as computation caching and error smoothing.

Many things are still missing, including some basics such as correct spectator and probably water movement.

Extremely off by default with no controls to turn it on by default. To toggle for current connection use `fo_beta_pmove 0/1`.