### PR TITLE
pmove: add persistent enable

### DIFF
--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -266,12 +266,8 @@ noref float(string cmd) CSQC_ConsoleCommand = {
             Slot_Keyup(stof(argv(1)));
             break;
 
-        case "fopm_cmd":
-            PM_PmCmd(stof(argv(1)));
-            break;
-
         case "fo_beta_pmove":
-            PM_PmCmd(!!stof(argv(1)));
+            printf("Please set `fo_pmove 1` instead.\n");
             break;
 
         case "login":

--- a/csqc/pmove.qc
+++ b/csqc/pmove.qc
@@ -34,10 +34,6 @@ struct {
     vector vieworg;
 } pm;
 
-void PM_PmCmd(float arg) {
-    sendevent("PmCmd", "f", arg);
-}
-
 vector PM_Org() { return PM_Enabled() ? pm.ent.origin : pmove_org; }
 vector PM_Vel() { return PM_Enabled() ? pm.ent.velocity : pmove_vel; }
 inline entity PM_Ent() { return pm.ent; }
@@ -160,7 +156,7 @@ void PM_PredictJump_Engine() {
 enum {
     SERVER,
     PMOVE,
-    VIEW,
+    ERROR,
     NUM_DBG_GRAPH_TYPES,
 };
 
@@ -366,7 +362,13 @@ static void PM_UpdateError() {
     } else { // figure out the error amount, and add it to accumulated lerp
         pm.error *= max(pm.errortime - time, 0) / ERRORTIME;
         pm.error += err;
-        pm.errortime = vlen(pm.error) > 1 ? time + ERRORTIME : 0;
+
+        if (vlen(pm.error) > 1)
+            pm.errortime = time + ERRORTIME;
+        else {
+            pm.error = '0 0 0';
+            pm.errortime = 0;
+        }
     }
 }
 
@@ -439,7 +441,8 @@ void PM_Update(float sendflags) {
     float was_enabled = PM_Enabled();
     float enabled = pstate_server.predict_flags & PF_PMOVE;
 
-    if (enabled != was_enabled)
+    if (enabled != was_enabled ||
+        game_state.is_player != prev_game_state.is_player)
         PM_SetEnabled(enabled);
 
     if (sendflags & FOWP_PMOVE == 0)
@@ -622,7 +625,7 @@ static void PMD_UpdateImpulse(int seq) {
 
     PMD_AddPoint(SERVER, vlen(sv));
     PMD_AddPoint(PMOVE,  vlen(pv));
-    PMD_AddPoint(VIEW, vlen(pm.error) / 128 * 1200);
+    PMD_AddPoint(ERROR, vlen(pm.error) / 128 * 1200);
 }
 
 static void PMD_Graph(int type, int offset, vector c1, vector c2, vector rgb) {
@@ -656,6 +659,11 @@ static void PMD_Graph(int type, int offset, vector c1, vector c2, vector rgb) {
 }
 
 void PMD_DrawGraphs(float width) {
+    float pmove_on = pstate_server.predict_flags & PF_PMOVE;
+    if (pmove_on)
+        drawstring([width - 100, 20, 0], sprintf("PM err: %0.1f", vlen(pm.error)),
+                   '8 8 0', '1 1 1', 1, 0);
+
     if (!CVARF(fopmd_graph))
         return;
 
@@ -673,6 +681,7 @@ void PMD_DrawGraphs(float width) {
 
     offset = max(0, offset);
     PMD_Graph(PMOVE, 0, c1, c2, '0 0 1');
-    PMD_Graph(VIEW, 0, c1, c2, '0 1 0');
     PMD_Graph(SERVER, offset, c1, c2, '1 0 0');
+    if (pstate_server.predict_flags & PF_PMOVE)
+        PMD_Graph(ERROR, 0, c1, c2, '0 1 0');
 }

--- a/csqc/weapon_predict.qc
+++ b/csqc/weapon_predict.qc
@@ -4,6 +4,9 @@ DEFCVAR_FLOAT(fo_wpp_beta, 0);
 DEFCVAR_FLOAT(fo_predict_weapons, 1);
 DEFCVAR_FLOAT(fo_predict_projectiles, 1);
 
+DEFCVAR_FLOAT(fo_pmove, 0);
+DEFCVAR_FLOAT(fopmd_force_pos, 0);
+
 DEFCVAR_FLOAT(fo_client_sniper_sight, 1);
 
 DEFCVAR_FLOAT(wpp_min_ping, -1);
@@ -360,6 +363,12 @@ void WPP_UpdateEnable(float force) {
         if (CVARF(fo_client_sniper_sight))
             wpp_status |= CSQC_SNIPER_SIGHT;
     }
+
+    // Set this independently of init above so that it can come up faster.
+    if (CVARF(fo_pmove))
+        wpp_status |= CSQC_PMOVE;
+    if (CVARF(fopmd_force_pos))
+        wpp_status |= CSQC_FORCE_POS;
 
     setlocaluserinfo(0, "fo_wpp_status", ftos(wpp_status));
     // We always need to "render" the view model to trigger predraw compute.

--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -116,20 +116,6 @@ float TFxEnabled(float flag) {
 
 const float TFX_DEFAULT_FLAGS = 0;
 
-enum CSQCFlags {
-    PREDICT_CSQC_SETSPEED,
-};
-
-string PREDICTF_DESC[] = {
-    "allow csqc to handle maxspeed"
-};
-
-inline float PredictEnabled(float flag) {
-    return fo_config.predict_flags & flag;
-};
-
-const float PREDICT_FLAGS_DEFAULT = 0;
-
 enumflags {
     FOC_ON_DEF,  // apply foc_defaults
     FOC_ON_NODEF,
@@ -300,6 +286,7 @@ enumflags {
 enumflags {
     CSQC_WEAP_PRED,
     CSQC_PROJ_PRED,
-    CSQC_SETSPEED,
+    CSQC_PMOVE,
+    CSQC_FORCE_POS,
     CSQC_SNIPER_SIGHT,
 };

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -43,13 +43,6 @@ enumflags {
 
 
 enumflags {
-    CSQC_WEAP_PRED,
-    CSQC_PROJ_PRED,
-    CSQC_SETSPEED,
-    CSQC_SNIPER_SIGHT,
-};
-
-enumflags {
     PF_PMOVE,
     PF_POS,
     PF_PMOVE_ACTIVATING,
@@ -351,7 +344,7 @@ static float Prediction_ChangedMask(entity player, entity src) {
     player.predict_state.client_time = src.client_time;
     player.predict_state.client_ping = src.client_ping;
 
-    if (player.predict_flags & PF_POS)
+    if (player.predict_flags & (PF_PMOVE | PF_POS))
         mask |= FOWP_PMOVE;
 
     M1(FOWP_CLASS, playerclass);
@@ -388,7 +381,10 @@ static float Prediction_ChangedMask(entity player, entity src) {
 }
 
 void Predict_InitPlayer(entity player);
-void Predict_Update() {
+void Predict_SyncPmove(float is_player);
+
+void Predict_Update(float is_player) {
+    Predict_SyncPmove(is_player);
     Predict_InitPlayer(self);
 
     // When spectating, goalentity is our target.
@@ -965,6 +961,77 @@ void FOProj_Finalize(entity mis, float use_ctime=0) {
             target = target.owner;  // Handle call from timer on latched throw.
         FO_Sound(target, CHAN_WEAPON, Snd_Get(SND_THROWGREN)->sound, 1, ATTN_NORM);
     }
+}
+
+.float pmt_nexttime;
+.float pmt_nextstate;
+
+enum PmtState {
+    PMT_INACTIVE,
+    PMT_ACTIVE,
+    PMT_ACTIVATE1,
+    PMT_ACTIVATE2,
+    PMT_DEACTIVATE1,
+    PMT_DEACTIVATE2,
+};
+
+float PmtBlockMaxSpeed() {
+    return self.pmt_nexttime != 0;  // When set, we're in transition edges.
+}
+
+void TeamFortress_SetSpeed(entity ent);
+void Predict_SyncPmove(float is_player) {
+    if (time < self.pmt_nexttime)
+        return;
+
+    float active = self.predict_flags & PF_PMOVE;
+    float want_active = (ClientPred_Enabled(self, CSQC_PMOVE)) && is_player;
+    float state = self.pmt_nextstate;
+
+    if (!active && want_active && state == PMT_INACTIVE)
+        state = PMT_ACTIVATE1;
+    else if (active && !want_active && state == PMT_ACTIVE)
+        state = PMT_DEACTIVATE1;
+
+    if (state == PMT_ACTIVE || state == PMT_INACTIVE) {
+        self.pmt_nexttime = 0;
+
+        if (state == PMT_INACTIVE) {
+            if (ClientPred_Enabled(self, CSQC_FORCE_POS))
+                self.predict_flags |= PF_POS;
+            else
+                self.predict_flags &= ~PF_POS;
+        }
+        return;
+    }
+
+    float next_step = 0.1;
+    switch (state) {
+        case PMT_ACTIVATE1:
+            self.predict_flags |= PF_POS;
+            self.maxspeed = SPEC_MAXSPEED;
+            self.pmt_nextstate = PMT_ACTIVATE2;
+            break;
+        case PMT_ACTIVATE2:
+            self.predict_flags |= PF_PMOVE;
+            self.nodrawtoclient = self;
+            TeamFortress_SetSpeed(self);
+            sprint(self, PRINT_HIGH, "*** PMOVE ACTIVATED\n");
+            self.pmt_nextstate = PMT_ACTIVE;
+            break;
+        case PMT_DEACTIVATE1:
+            next_step = 2;
+            self.nodrawtoclient = world;
+            TeamFortress_SetSpeed(self);
+            self.pmt_nextstate = PMT_DEACTIVATE2;
+            break;
+        case PMT_DEACTIVATE2:
+            self.predict_flags &= ~(PF_PMOVE | PF_POS);
+            sprint(self, PRINT_HIGH, "*** PMOVE DEACTIVATED\n");
+            self.pmt_nextstate = PMT_INACTIVE;
+            break;
+    }
+    self.pmt_nexttime = time + next_step;
 }
 #endif
 

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -3010,7 +3010,7 @@ void () PlayerPostThink = {
 
     FOPlayer fop = (FOPlayer)self;
     fop.RewindUpdate();
-    Predict_Update();
+    Predict_Update(TRUE);
 };
 
 void () UpdateAllClientsTeamScores = {
@@ -3886,53 +3886,3 @@ void() SV_RunClientCommand = {
     self.jump_flag = self.velocity_z;
 }
 */
-
-static void DeferredPmoveAction() {
-    entity player = self.owner;
-    player.predict_flags &= ~PF_PMOVE_ACTIVATING;
-
-    if (self.heat) {
-        sprint(player, PRINT_HIGH, "*** PMOVE ACTIVATED\n");
-        player.nodrawtoclient = player;
-        player.predict_flags |= PF_PMOVE;
-        TeamFortress_SetSpeed(player);
-    } else {
-        sprint(player, PRINT_HIGH, "*** PMOVE INACTIVE\n");
-        player.predict_flags &= ~PF_PMOVE;
-    }
-    remove(self);
-}
-
-void (float active) CSEv_PmCmd_f = {
-    if (self.predict_flags & PF_PMOVE_ACTIVATING) {
-        sprint(self, PRINT_HIGH, "Please wait for prior activation to complete...\n");
-        return;
-    }
-
-    if (active & PF_PMOVE)
-        active |= PF_POS;
-
-    self.predict_flags &= ~PF_POS;
-    self.predict_flags |= (active & PF_POS);
-
-    if ((active & PF_PMOVE) == (self.predict_flags & PF_PMOVE))
-        return;
-
-    float enable = active & PF_PMOVE;
-    if (enable) {
-        // This is messy; maxspeed exists only in hidden inband communication
-        // with the client.  We need to push a high value to the client before
-        // we obscure the client since it won't see further updates (which might
-        // increase when changing classes).
-        self.maxspeed = SPEC_MAXSPEED;
-    } else {
-        self.nodrawtoclient = world;
-    }
-
-    self.predict_flags |= PF_PMOVE_ACTIVATING;
-    entity defer = spawn();
-    defer.owner = self;
-    defer.think = DeferredPmoveAction;
-    defer.heat = enable;
-    defer.nextthink = time + 0.1;
-}

--- a/ssqc/spect.qc
+++ b/ssqc/spect.qc
@@ -162,5 +162,5 @@ void () SpectatorThink = {
         RefreshStatusBar(self);
     }
 
-    Predict_Update();
+    Predict_Update(FALSE);
 };

--- a/ssqc/tfort.qc
+++ b/ssqc/tfort.qc
@@ -982,6 +982,14 @@ float (float pc) IsLegalClass = {
     return (TRUE);
 };
 
+float PmtBlockMaxSpeed();
+
+static void SetMaxSpeed(entity p, float speed) {
+    p.csqc_maxspeed = speed;
+    if (!PmtBlockMaxSpeed())
+        p.maxspeed = speed;
+}
+
 void (entity p) TeamFortress_SetSpeed = {
     string sp;
     float tf;
@@ -989,14 +997,14 @@ void (entity p) TeamFortress_SetSpeed = {
 
     if (p.tfstate & TFSTATE_CANT_MOVE) {
         p.velocity = '0 0 0';
-        p.csqc_maxspeed = p.maxspeed = 0;
+        SetMaxSpeed(p, 0);
         return;
     }
 
     if (p.playerclass == PC_UNDEFINED) {
         // Typically this hits spectators and then spec movetype --> maxspeed
         // actually ignored.
-        p.csqc_maxspeed = p.maxspeed = SPEC_MAXSPEED;
+        SetMaxSpeed(p, SPEC_MAXSPEED);
         stuffcmd(p, "cl_movespeedkey 1;cl_backspeed 500; cl_forwardspeed 500; cl_sidespeed 500;cl_upspeed 500;\n");
         return;
     }
@@ -1030,8 +1038,8 @@ void (entity p) TeamFortress_SetSpeed = {
             new_max = min(new_max, 80);
 #endif
 
-    p.maxspeed = p.csqc_maxspeed = new_max;
-};
+    SetMaxSpeed(p, new_max);
+}
 
 void () TeamFortress_SetHealth = {
     if (self.playerclass == PC_SCOUT) {


### PR DESCRIPTION
pmove can now be turned on with a persistent enable: `fo_pmove 0/1`. Also smooth out how much the view bounces around during transitions and prevent races on maxspeed.