### PR TITLE
core: finish removing s_time from server side, fix entity removal

### DIFF
--- a/share/commondefs.qc
+++ b/share/commondefs.qc
@@ -172,7 +172,6 @@ const float SERVER_FRAME_DT = 1/SERVER_FPS;
 const float SERVER_FRAME_MS = SERVER_FRAME_DT * 1000.0;
 
 .vector s_origin;
-.float s_time;
 
 #define MAX_FLAGINFO_LINES  10
 #define ENG_BUILDING_DISMANTLE_DISTANCE 100

--- a/share/prediction.qc
+++ b/share/prediction.qc
@@ -451,6 +451,7 @@ void InitProjectileEnt(float sendflags);
 void WPP_UpdateEnable(float force);
 
 .float owner_entnum;
+.float s_time;
 #endif
 
 #ifdef SSQC

--- a/ssqc/debug.qc
+++ b/ssqc/debug.qc
@@ -16,17 +16,17 @@ void (entity te) dremove =
     remove(te);
 };
 
+.float created_at;  // Forward dec
 void dremove_sent(entity te) {
-    static const float epsilon = 3*SERVER_FRAME_DT;
-    float stime = te.s_time;
-    if (!stime)
-        stime = time;
+    static const float epsilon = 2*SERVER_FRAME_DT;
 
-    if (time > stime + epsilon) {
-        dremove(self);
+    float expires = te.created_at + epsilon;  // In the past for 0 created at
+
+    if (time > expires) {
+        dremove(te);
     } else {
-        self.nextthink = stime + epsilon;
-        self.think = SUB_Remove;
+        te.nextthink = expires;
+        te.think = SUB_Remove;
     }
 }
 

--- a/ssqc/rewind.qc
+++ b/ssqc/rewind.qc
@@ -385,7 +385,7 @@ void Forward_Projectile(int fpp_type, entity proj, float use_ctime) {
     // a prior point in time, but we don't advance time while stepping.
     float ft = Phys_Init(proj, stime, static_dt, PHYSF_CONSUME_ALL);
 
-    // We initialize s_origin/s_time after Phys_Init, they are used when
+    // We initialize s_origin after Phys_Init, they are used when
     // knockback forwarding is on to determine delay.
     if (rewind_hit && RewindFlagEnabled(REWIND_FORWARD_PROJ_SELFKNOCK)) {
         phys_flags |= PHYSF_FORWARD_KNOCK;


### PR DESCRIPTION
This fixes leaking ents with sky collisions.