### PR TITLE
core: split tfstate into pstate

### DIFF
--- a/share/defs.h
+++ b/share/defs.h
@@ -259,21 +259,25 @@ enumflags {
     TFSTATE_AC_SPINDOWN,
     TFSTATE_LOCK,          // assault cannon locked
     TFSTATE_INFECTED,      // set when player is infected by the bioweapon
-    TFSTATE_INVINCIBLE,    // Player has permanent Invincibility (Usually by GoalItem)
-    TFSTATE_INVISIBLE,     // Player has permanent Invisibility (Usually by GoalItem)
-    TFSTATE_QUAD,          // Player has permanent Quad Damage (Usually by GoalItem)
-    TFSTATE_RADSUIT,       // Player has permanent Radsuit (Usually by GoalItem)
     TFSTATE_BURNING,       // Is on fire
     TFSTATE_FEIGNED,       // Is feigned
     TFSTATE_AIMING,        // is using the laser sight or spinning cannon
     TFSTATE_RESPAWN_READY, // is waiting for respawn, and has pressed fire,
                            // as sentry gun,indicate it needs to die
     TFSTATE_HALLUCINATING, // set when player is hallucinating
-    TFSTATE_TRANQUILISED,  // set when player is tranquilised
+
     TFSTATE_FLAMES_MAX,    // Peak burnination.
+    TFSTATE_TRANQUILISED,  // set when player is tranquilised
     TFSTATE_RANDOMPC,
+    // QC/Compiler limitation: Bits past-24 unsafe with bitops
 };
 
+enumflags {
+    PSTATE_INVINCIBLE,    // Player has permanent Invincibility (Usually by GoalItem)
+    PSTATE_INVISIBLE,     // Player has permanent Invisibility (Usually by GoalItem)
+    PSTATE_QUAD,          // Player has permanent Quad Damage (Usually by GoalItem)
+    PSTATE_RADSUIT,       // Player has permanent Radsuit (Usually by GoalItem)
+};
 
 #define TFSTATE_GREN_MASK_PRIMED (TFSTATE_GREN1_PRIMED|TFSTATE_GREN2_PRIMED)
 #define TFSTATE_GREN_MASK_ALL (TFSTATE_GREN_MASK_PRIMED|TFSTATE_GRENTHROWING)

--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -2844,7 +2844,7 @@ void () CheckPowerups = {
             self.modelindex = modelindex_eyes;
         } else {
             if (self.invisible_finished) {
-                if (self.tfstate & TFSTATE_INVISIBLE) {
+                if (self.pstate & PSTATE_INVISIBLE) {
                     if (self.invisible_finished < (time + 10)) {
                         self.invisible_finished = time + 666;
                     }
@@ -2879,7 +2879,7 @@ void () CheckPowerups = {
         }
     }
     if (self.invincible_finished) {
-        if (self.tfstate & TFSTATE_INVINCIBLE) {
+        if (self.pstate & PSTATE_INVINCIBLE) {
             if (self.invincible_finished < (time + 10)) {
                 self.invincible_finished = time + 666;
             }
@@ -2923,7 +2923,7 @@ void () CheckPowerups = {
         }
     }
     if (self.super_damage_finished) {
-        if (self.tfstate & TFSTATE_QUAD) {
+        if (self.pstate & PSTATE_QUAD) {
             if (self.super_damage_finished == (time + 10)) {
                 self.super_damage_finished = time + 666;
             }
@@ -2965,7 +2965,7 @@ void () CheckPowerups = {
     }
     if (self.radsuit_finished) {
         self.air_finished = time + 12;
-        if (self.tfstate & TFSTATE_RADSUIT) {
+        if (self.pstate & PSTATE_RADSUIT) {
             if (self.radsuit_finished == (time + 10)) {
                 self.radsuit_finished = time + 666;
             }

--- a/ssqc/qw.qc
+++ b/ssqc/qw.qc
@@ -108,6 +108,7 @@ float remote_client_time();
 
 .entity nopickup;               // Don't pick up this backpack/ammobox because it doesn't contain any of your ammo types
 
+.float pstate;                  // Player state flags
 .float tfstate;                 // State flags for TeamFortress
 .float last_tfstate;             // Internal cache of tfstate for detecting updates
 .entity linked_list;            // Used just like chain. Has to be separate so

--- a/ssqc/tfortmap.qc
+++ b/ssqc/tfortmap.qc
@@ -908,7 +908,7 @@ void (entity Goal, entity Player, entity AP, float addb) Apply_Results = {
                     Player.invincible_finished =
                         time + Goal.invincible_finished;
                     if (Goal.classname == "item_tfgoal") {
-                        Player.tfstate = Player.tfstate | TFSTATE_INVINCIBLE;
+                        Player.pstate |= PSTATE_INVINCIBLE;
                         Player.invincible_finished = time + 666;
                     }
                 }
@@ -917,7 +917,7 @@ void (entity Goal, entity Player, entity AP, float addb) Apply_Results = {
                     Player.invisible_time = 1;
                     Player.invisible_finished = time + Goal.invisible_finished;
                     if (Goal.classname == "item_tfgoal") {
-                        Player.tfstate = Player.tfstate | TFSTATE_INVISIBLE;
+                        Player.pstate |= PSTATE_INVISIBLE;
                         Player.invisible_finished = time + 666;
                     }
                 }
@@ -927,7 +927,7 @@ void (entity Goal, entity Player, entity AP, float addb) Apply_Results = {
                     Player.super_damage_finished =
                         time + Goal.super_damage_finished;
                     if (Goal.classname == "item_tfgoal") {
-                        Player.tfstate = Player.tfstate | TFSTATE_QUAD;
+                        Player.pstate |= PSTATE_QUAD;
                         Player.super_damage_finished = time + 666;
                     }
                 }
@@ -936,7 +936,7 @@ void (entity Goal, entity Player, entity AP, float addb) Apply_Results = {
                     Player.rad_time = 1;
                     Player.radsuit_finished = time + Goal.radsuit_finished;
                     if (Goal.classname == "item_tfgoal") {
-                        Player.tfstate = Player.tfstate | TFSTATE_RADSUIT;
+                        Player.pstate |= PSTATE_RADSUIT;
                         Player.radsuit_finished = time + 666;
                     }
                 }
@@ -1179,25 +1179,25 @@ void (entity Goal, entity Player) RemoveResults = {
         te = find(te, classname, "item_tfgoal");
     }
     if ((Goal.invincible_finished > 0) && !puinvin) {
-        Player.tfstate &= ~TFSTATE_INVINCIBLE;
+        Player.pstate &= ~PSTATE_INVINCIBLE;
         Player.items = Player.items | IT_INVULNERABILITY;
         Player.invincible_time = 1;
         Player.invincible_finished = time + Goal.invincible_finished;
     }
     if ((Goal.invisible_finished > 0) && !puinvis) {
-        Player.tfstate &= ~TFSTATE_INVISIBLE;
+        Player.pstate &= ~PSTATE_INVISIBLE;
         Player.items = Player.items | IT_INVISIBILITY;
         Player.invisible_time = 1;
         Player.invisible_finished = time + Goal.invisible_finished;
     }
     if ((Goal.super_damage_finished > 0) && !puquad) {
-        Player.tfstate &= ~TFSTATE_QUAD;
+        Player.pstate &= ~PSTATE_QUAD;
         Player.items = Player.items | IT_QUAD;
         Player.super_time = 1;
         Player.super_damage_finished = time + Goal.super_damage_finished;
     }
     if ((Goal.radsuit_finished > 0) && !purad) {
-        Player.tfstate &= ~TFSTATE_RADSUIT;
+        Player.pstate &= ~PSTATE_RADSUIT;
         Player.items = Player.items | IT_SUIT;
         Player.rad_time = 1;
         Player.radsuit_finished = time + Goal.radsuit_finished;

--- a/ssqc/weapons.qc
+++ b/ssqc/weapons.qc
@@ -2676,16 +2676,16 @@ void () SuperDamageSound = {
 };
 
 void () ToggleInvincibility = {
-    if(self.tfstate & TFSTATE_INVINCIBLE) {
+    if(self.pstate & PSTATE_INVINCIBLE) {
         self.items &= ~IT_INVULNERABILITY;
         self.invincible_time = 0;
         self.invincible_finished = 0;
-        self.tfstate &= ~TFSTATE_INVINCIBLE;
+        self.tfstate &= ~PSTATE_INVINCIBLE;
         self.effects &= ~(EF_RED | EF_DIMLIGHT | EF_BRIGHTLIGHT);
     } else {
         self.items |= IT_INVULNERABILITY;
         self.invincible_time = 1;
-        self.tfstate |= TFSTATE_INVINCIBLE;
+        self.pstate |= PSTATE_INVINCIBLE;
         self.invincible_finished = time + 666;
     }
 };


### PR DESCRIPTION
size limits(?) on bitops dont play well with large enumflags values.  Split tfstate into a second word, moving some of our less commonly used fields for now.

This fixes issues like infinite tranq