### PR TITLE
weapons: fix firing after dead when gibbed

### DIFF
--- a/share/animate.qc
+++ b/share/animate.qc
@@ -46,6 +46,9 @@ void FO_SetClientThink(void() func, float offset, float override = TRUE) {
 }
 
 void client_anim_frames(void() parent_thunk, void() extra, anim_t* anim) {
+    if (self.deadflag)
+        return;
+
     float tidx = *thinkindex()++ - 1;
 
     int wfi = tidx % anim->num_wf;


### PR DESCRIPTION
Being gibbed does not reset some of the animation state and so weapons which fired in animation were able to continue firing.  Prevent this.