### PR TITLE
core: make haze-stats align better with in-game stats

### DIFF
--- a/ssqc/events.qc
+++ b/ssqc/events.qc
@@ -195,7 +195,7 @@ void (entity attacker, entity target, entity inflictor, float damage, float true
 
         part2 = sprintf("\"inflictor\": \"%s\", \"damage\": %s, \"time\": %s, \"gameTimeStamp\": \"%s\"}", 
                 inflictorId,
-                ftos(damage),
+                ftos(truedam),
                 ftos(gametime),
                 gametimestamp
                 );


### PR DESCRIPTION
haze-stats currently behaves differently wrt over-damage (e.g. more damage than it takes to kill someone) than in-game stats.  The in-game stats only log the damage actually done while haze-stats includes the "over" damage.

Align this by logging true-damage for both.