### PR TITLE
demoman: disable allpipes_cooldown by default

### DIFF
--- a/ssqc/client.qc
+++ b/ssqc/client.qc
@@ -519,8 +519,8 @@ void () DecodeLevelParms = {
         // set pipe cooldown time [0.5]
         pipecooldown_time = CF_GetSetting("pcdt", "pipecooldown_time", "0.5");
 
-        // cooldown applies to all pipes [off]
-        allpipes_cooldown = CF_GetSetting("apcd", "allpipes_cooldown", "off");
+        // cooldown applies to all pipes [on]
+        allpipes_cooldown = CF_GetSetting("apcd", "allpipes_cooldown", "on");
 
         // allow medic aura [on]
         medicaura = CF_GetSetting("ma", "medicaura", "on");


### PR DESCRIPTION
To enable for testing:
  `rcon localinfo apcd 1`