### PR TITLE
core: make special act like +special

### DIFF
--- a/csqc/csextradefs.qc
+++ b/csqc/csextradefs.qc
@@ -920,3 +920,4 @@ void cvar_parse4(string s, __out veci target) {
 }
 
 float servertime;
+float special_until;

--- a/csqc/main.qc
+++ b/csqc/main.qc
@@ -140,6 +140,7 @@ noref void(float apiver, string enginename, float enginever) CSQC_Init = {
     registercommand("-rj");
 
     registercommand("slot_a");
+    registercommand("special");
 
     registercommand("+fo_showscores");
     registercommand("-fo_showscores");
@@ -454,6 +455,9 @@ noref float(string cmd) CSQC_ConsoleCommand = {
         case "slot_a":  // Alternate between passed options
             W_ChangeToSlotAlternate(argv(1), argv(2), argv(3), argv(4));
             break;
+        case "special":
+            special_until = time + 0.150;
+            break;
     }
 
     return FALSE;
@@ -652,6 +656,10 @@ noref void CSQC_Input_Frame() {
     if ((WP_PlayerClass() == PC_SOLDIER || WP_PlayerClass() == PC_PYRO) &&
         (input_buttons & BUTTON4))
         input_buttons |= BUTTON0 | BUTTON2;
+
+    // Set +special when special used
+    if (time < special_until)
+        input_buttons |= BUTTON3;
 
     // Handle zoom
     float prev_zoomed_in = zoomed_in;

--- a/share/defs.h
+++ b/share/defs.h
@@ -1574,7 +1574,7 @@ TFAlias client_aliases[] = {
     {"dropflag",                TF_DROPFLAG},
     {"dropitems",               TF_DROPFLAG},
     {"showloc",                 TF_DISPLAYLOCATION},
-    {"special",                 TF_SPECIAL_SKILL},
+    /* {"special",                 TF_SPECIAL_SKILL}, */
     {"special2",                TF_SPECIAL_SKILL_2},
     {"saveme",                  TF_MEDIC_HELPME},
     {"discard",                 TF_DISCARD},


### PR DESCRIPTION
+special has advantaged behavior over special because it expresses for more than a single frame, especially for actions such as detpipe.

However, +special cannot be bound to keys that do not release, such as mwheel. Change special to express +special for 150ms to minimize this advantage.