### PR TITLE
pmove: fix maxspeed

### DIFF
--- a/csqc/pmove.qc
+++ b/csqc/pmove.qc
@@ -872,12 +872,7 @@ void PM_InputFrame() {
     float iz = input_movevalues.z;
     input_movevalues.z = 0;
 
-    float max_speed;
-    if (isdemo) {
-        max_speed = SPEC_MAXSPEED;
-    } else {
-        max_speed = pstate_pred.csqc_maxspeed;
-    }
+    float max_speed = isdemo() ? SPEC_MAXSPEED : pstate_pred.csqc_maxspeed;
 
 #if 0  // Quick fix
     // cl_smartjump replacement


### PR DESCRIPTION
was using if (function_ptr) [always true] instead of calling function